### PR TITLE
Add travis yaml file to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+- '2.7'
+- '3.6'
+sudo: required
+services: docker
+install: pip install -r requirements.txt -r test-requirements.txt
+script: python -m unittest discover -v
+notifications:
+  slack:
+    on_success: change
+    on_failure: always
+    rooms:
+      secure: iwNFxUcHIiThEGCpHNRYbLdwfEuQ0IrMZoN4hh73LupeuF1XVISoUJwvJER6cYKphwy4IXmdalilvH9AsVNBuWtY0RPZy44gKYDjXyViQiup67uChQ5u7I4t9d9WcuTor3tFY0+f9ACmqoMl8GcRyKrUwRg1tknmDG+B5sJ9NXW/dQ1Xfk8mArgx0kYpAVFjHmGIxrBvKu57p370spe7CIFFf60iCmV4Q2ty8UkciOwjBHcYCh09JdgjKKMNIRF5aYqI2j/009AQHX0/eCYxou7H6vOflEP8pVMiGt/4SbnEs8nenwUcr9i9u0oBVs4p0GJA/qiTwy9XXPYymcePTU39huSS2r+6dkzeAwVsNK3hoxXvhhtLj8gatGuE92s2l59y5sWLfZb+lnTRMYrt2ZVnXzIlHrAV65gHUIXSD2it59o0Gl6SqChPg2H96ZTma9rBKB926nhf1Q7AvZOc7f2e0v3aSm5Ogz5wtHN2L5PVdYZgSnec8CbzW10nNZscBDqN2aSeZgxzQOU1AGp577RJ+MNtYmtPRJ8fZFgZs2r5KZas9sYJRhRBlGmJV60AnvpZ38mQaCnCzxkU75HZuaqa/wX/JissxxkZj0Gx4HNyHbssrzDIJLT6WxnoggHKSuv7NF1vheBbkC503DoPZV9+YrNOixi5bNQR3y2tMR0=

--- a/cromwell_tools/cromwell_tools.py
+++ b/cromwell_tools/cromwell_tools.py
@@ -8,11 +8,7 @@ from datetime import datetime, timedelta
 import time
 import requests
 from requests.auth import HTTPBasicAuth
-
-if sys.version_info < (3, 0):
-    from StringIO import StringIO
-else:
-    from io import StringIO
+import six
 
 
 _failed_statuses = ['Failed', 'Aborted', 'Aborting']
@@ -167,14 +163,13 @@ def make_zip_in_memory(url_to_contents):
     containing each file. For each url, the part after the last slash is used
     as the file name when writing to the zip archive.
     """
-    buf = StringIO()
+    buf = six.BytesIO()
     with zipfile.ZipFile(buf, 'w') as zip_buffer:
         for url, contents in url_to_contents.items():
             name = url.split('/')[-1]
             zip_buffer.writestr(name, contents)
 
-    bytes_buf = io.BytesIO(buf.getvalue())
-    return bytes_buf
+    return buf
 
 
 def download(url):
@@ -194,7 +189,7 @@ def download_http(url):
     Makes an http request for the contents at the given url and returns the response body.
     """
     response = requests.get(url)
-    response_str = response.text.encode('utf-8')
+    response_str = response.text
     return response_str
 
 

--- a/cromwell_tools/tests/test_cromwell_tools.py
+++ b/cromwell_tools/tests/test_cromwell_tools.py
@@ -68,8 +68,8 @@ class TestUtils(unittest.TestCase):
                 f1_contents = f1.read()
             with zf.open('b.txt') as f2:
                 f2_contents = f2.read()
-        self.assertEqual(f1_contents, 'aaa\n')
-        self.assertEqual(f2_contents, 'bbb\n')
+        self.assertEqual(f1_contents, b'aaa\n')
+        self.assertEqual(f2_contents, b'bbb\n')
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+six


### PR DESCRIPTION
Added ```.travis.yml``` to run unit tests in both Python 2 and 3.

Fixed Python 3 compatibility problems:
-Use six.BytesIO instead of io.StringIO when making zip file (zipfile won't accept io.StringIO in 3, but will accept six.BytesIO in both 2 and 3)
-Fix assertion in test to work in both 2 and 3