### PR TITLE
Fix zip problems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     packages=['cromwell_tools'],
     install_requires=[
         'requests',
+        'six'
     ],
     scripts=['cromwell_tools/scripts/cromwell-tools'],
     include_package_data=True


### PR DESCRIPTION
I broke things in an earlier attempt to make cromwell_tools compatible with both Python 2 and 3 (#6).

Compatibility with 2 and 3 is maintained here, but this PR fixes several issues:
- I was getting a UnicodeDecodeError in make_zip_in_memory. Fixed by adding `.encode('utf-8')` in `download_http`.
- Cromwell was not able to find any of the files in the zip. Fixed by converting to `io.BytesIO` in `make_zip_in_memory`.
- `six` was missing from setup.py `install_requires`, causing an import error when trying to use cromwell_tools
- Tweaked test data to make it more realistic (added `.encode` for strings)
- wdlSource and wdlDependencies have been renamed in newer versions of Cromwell to workflowSource and workflowDependencies. I updated those fields accordingly in `start_workflow`.

See https://elastc.com/c/0v6eJH1B/465-updating-lira-to-handle-subworkflows


  