### PR TITLE
Add option to use Cromwell-as-a-service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.18.4
 six==1.11.0
 tenacity==4.10.0
+oauth2client==4.1.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ setup(
     packages=['cromwell_tools'],
     install_requires=[
         'requests==2.18.4',
-        'six==1.11.0'
+        'six==1.11.0',
+        'oauth2client==4.1.2',
+        'tenacity==4.10.0'
     ],
     scripts=['cromwell_tools/scripts/cromwell-tools'],
     include_package_data=True

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-mock
-requests_mock
+mock==2.0.0
+requests_mock==1.4.0


### PR DESCRIPTION
In addition to user/password authentication to an instance of Cromwell, update the functions in cromwell-tools to include the ability to make calls to Cromwell-as-a-service with a bearer token.