### PR TITLE
Enable Cromwell-tools to add labels at submission time

### DIFF
--- a/cromwell_tools/cromwell_tools.py
+++ b/cromwell_tools/cromwell_tools.py
@@ -272,7 +272,7 @@ def _fullmatch(regex, string, flags=0):
 
     :param str regex: A regex string.
     :param str string: The string that you want to apply regex match to.
-    :param str/int flags: The expression’s behaviour can be modified by specifying a flags value. Values can be any of
+    :param str|int flags: The expression's behaviour can be modified by specifying a flags value. Values can be any of
      the variables listed in https://docs.python.org/3/library/re.html
 
     :return SRE_Match/None: return a corresponding match object, or None if the string does not match the pattern.

--- a/cromwell_tools/cromwell_tools.py
+++ b/cromwell_tools/cromwell_tools.py
@@ -13,7 +13,7 @@ import re
 
 _failed_statuses = ['Failed', 'Aborted', 'Aborting']
 
-# Note: below rules for validating labels are based on Cromwell's documentation:
+# Note: the following rules for validating labels are based on Cromwell's documentation:
 # https://cromwell.readthedocs.io/en/develop/Labels/ and they could be changed in the future.
 _CROMWELL_LABEL_LENGTH = 63
 _CROMWELL_LABEL_KEY_REGEX = '[a-z]([-a-z0-9]*[a-z0-9])?'

--- a/cromwell_tools/cromwell_tools.py
+++ b/cromwell_tools/cromwell_tools.py
@@ -252,8 +252,13 @@ def validate_cromwell_label(label_object):
 
 
 def _label_content_checker(regex, content):
-    if not re.fullmatch(regex, content):
-        # raise ValueError('Invalid label: {0} did not match the regex {1}'.format(content, regex))
+
+    try:
+        matched = re.fullmatch(regex, content)
+    except AttributeError:
+        matched = _fullmatch(regex, content)
+
+    if not matched:
         return 'Invalid label: {0} did not match the regex {1}.\n'.format(content, regex)
     else:
         return ""
@@ -264,3 +269,8 @@ def _label_length_checker(length, content):
         return 'Invalid label: {0} has {1} characters. The maximum is {2}.\n'.format(content, len(content), length)
     else:
         return ""
+
+
+def _fullmatch(regex, string, flags=0):
+    """Backport Python 3.4's regular expression "fullmatch()" to Python 2 by emulating python-3.4 re.fullmatch()."""
+    return re.match("(?:" + regex + r")\Z", string, flags=flags)

--- a/cromwell_tools/cromwell_tools.py
+++ b/cromwell_tools/cromwell_tools.py
@@ -1,7 +1,6 @@
 """This module contains utility functions to interact with Cromwell.
 """
 import io
-import sys
 import zipfile
 import json
 from datetime import datetime, timedelta
@@ -9,7 +8,6 @@ import time
 import requests
 from requests.auth import HTTPBasicAuth
 import six
-import re
 
 
 _failed_statuses = ['Failed', 'Aborted', 'Aborting']

--- a/cromwell_tools/cromwell_tools.py
+++ b/cromwell_tools/cromwell_tools.py
@@ -130,7 +130,7 @@ def start_workflow(
     :param _io.BytesIO zip_file: (optional) zip file containing dependencies.
     :param str user: (optional) cromwell username.
     :param str password: (optional) cromwell password.
-    :param _io.BytesIO label: (optional) JSON file containing a collection of key/value pairs for workflow labels.
+    :param str|_io.BytesIO label: (optional) JSON file containing a collection of key/value pairs for workflow labels.
     :param bool validate_labels: (optional) Whether to validate labels or not, using cromwell-tools' built-in
      validators. It is set to True by default.
 
@@ -287,7 +287,7 @@ def validate_cromwell_label(label_object):
         Both the docs and the code base of Cromwell could possibly change in the future, please update this
         checker on demand.
 
-    :param str label_object: A dictionary or a key-value object string that define a Cromwell label.
+    :param str|_io.BytesIO label_object: A dictionary or a key-value object string that define a Cromwell label.
 
     :raises ValueError: This validator will raise an exception if the label_object is invalid as a Cromwell label.
     """

--- a/cromwell_tools/tests/test_cromwell_tools.py
+++ b/cromwell_tools/tests/test_cromwell_tools.py
@@ -12,7 +12,6 @@ except ImportError:
 from cromwell_tools import cromwell_tools
 import zipfile
 import os
-import json
 
 
 class TestUtils(unittest.TestCase):

--- a/cromwell_tools/tests/test_cromwell_tools.py
+++ b/cromwell_tools/tests/test_cromwell_tools.py
@@ -22,16 +22,6 @@ class TestUtils(unittest.TestCase):
         # Change to test directory, as tests may have been invoked from another dir
         dir = os.path.abspath(os.path.dirname(__file__))
         os.chdir(dir)
-        cls.invalid_labels = {"0-label-key-1": "0-label-value-1",
-                            "the-maximum-allowed-character-length-for-label-pairs-is-sixty-three":
-                                "cromwell-please-dont-validate-these-labels",
-                            "": "not a great label key",
-                            "Comment": "This-is-a-test-label"}
-        cls.valid_labels = {"label-key-1": "label-value-1",
-                        "label-key-2": "label-value-2",
-                        "only-key": "",
-                        "fc-id": "0123-abcd-4567-efgh",
-                        "comment": "this-is-a-test-label"}
 
     @requests_mock.mock()
     def test_start_workflow(self, mock_request):
@@ -129,27 +119,6 @@ class TestUtils(unittest.TestCase):
                 f2_contents = f2.read()
         self.assertEqual(f1_contents, b'aaa\n')
         self.assertEqual(f2_contents, b'bbb\n')
-
-    def test_validate_cromwell_label_on_invalid_labels_object(self):
-        self.assertRaises(ValueError, cromwell_tools.validate_cromwell_label,
-                          self.invalid_labels)
-
-    def test_validate_cromwell_label_on_invalid_labels_str_object(self):
-        self.assertRaises(ValueError, cromwell_tools.validate_cromwell_label,
-                          json.dumps(self.invalid_labels))
-
-    def test_validate_cromwell_label_on_invalid_labels_bytes_object(self):
-        self.assertRaises(ValueError, cromwell_tools.validate_cromwell_label,
-                          json.dumps(self.invalid_labels).encode('utf-8'))
-
-    def test_validate_cromwell_label_on_valid_labels_object(self):
-        self.assertTrue(cromwell_tools.validate_cromwell_label(self.valid_labels))
-
-    def test_validate_cromwell_label_on_valid_labels_str_object(self):
-        self.assertTrue(cromwell_tools.validate_cromwell_label(json.dumps(self.valid_labels)))
-
-    def test_validate_cromwell_label_on_valid_labels_bytes_object(self):
-        self.assertTrue(cromwell_tools.validate_cromwell_label(json.dumps(self.valid_labels).encode('utf-8')))
 
 
 if __name__ == '__main__':

--- a/cromwell_tools/tests/test_cromwell_tools.py
+++ b/cromwell_tools/tests/test_cromwell_tools.py
@@ -21,6 +21,14 @@ class TestUtils(unittest.TestCase):
         # Change to test directory, as tests may have been invoked from another dir
         dir = os.path.abspath(os.path.dirname(__file__))
         os.chdir(dir)
+        cls.invalid_labels = {"0-label-key-1": "0-label-value-1",
+                            "the-maximum-allowed-character-length-for-label-pairs-is-sixty-three":
+                                "cromwell-please-dont-validate-these-labels",
+                            "": "not a great label key"}
+        cls.valid_labels = {"label-key-1": "label-value-1",
+                        "label-key-2": "label-value-2",
+                        "only-key": "",
+                        "fc-id": "0123-abcd-4567-efgh"}
 
     @requests_mock.mock()
     def test_start_workflow(self, mock_request):
@@ -117,6 +125,12 @@ class TestUtils(unittest.TestCase):
                 f2_contents = f2.read()
         self.assertEqual(f1_contents, b'aaa\n')
         self.assertEqual(f2_contents, b'bbb\n')
+
+    def test_validate_cromwell_label_on_invalid_labels(self):
+        self.assertRaises(ValueError, cromwell_tools.validate_cromwell_label, self.invalid_labels)
+
+    def test_validate_cromwell_label_on_valid_labels(self):
+        self.assertTrue(cromwell_tools.validate_cromwell_label(self.valid_labels))
 
 
 if __name__ == '__main__':

--- a/cromwell_tools/tests/test_cromwell_tools.py
+++ b/cromwell_tools/tests/test_cromwell_tools.py
@@ -12,6 +12,7 @@ except ImportError:
 from cromwell_tools import cromwell_tools
 import zipfile
 import os
+import json
 
 
 class TestUtils(unittest.TestCase):
@@ -21,6 +22,20 @@ class TestUtils(unittest.TestCase):
         # Change to test directory, as tests may have been invoked from another dir
         dir = os.path.abspath(os.path.dirname(__file__))
         os.chdir(dir)
+        cls.invalid_labels = {
+            "0-label-key-1": "0-label-value-1",
+            "the-maximum-allowed-character-length-for-label-pairs-is-sixty-three":
+                "cromwell-please-dont-validate-these-labels",
+            "": "not a great label key",
+            "Comment": "This-is-a-test-label"
+        }
+        cls.valid_labels = {
+            "label-key-1": "label-value-1",
+            "label-key-2": "label-value-2",
+            "only-key": "",
+            "fc-id": "0123-abcd-4567-efgh",
+            "comment": "this-is-a-test-label"
+        }
 
     @requests_mock.mock()
     def test_start_workflow(self, mock_request):
@@ -118,6 +133,27 @@ class TestUtils(unittest.TestCase):
                 f2_contents = f2.read()
         self.assertEqual(f1_contents, b'aaa\n')
         self.assertEqual(f2_contents, b'bbb\n')
+
+    def test_validate_cromwell_label_on_invalid_labels_object(self):
+        self.assertRaises(ValueError, cromwell_tools.validate_cromwell_label,
+                          self.invalid_labels)
+
+    def test_validate_cromwell_label_on_invalid_labels_str_object(self):
+        self.assertRaises(ValueError, cromwell_tools.validate_cromwell_label,
+                          json.dumps(self.invalid_labels))
+
+    def test_validate_cromwell_label_on_invalid_labels_bytes_object(self):
+        self.assertRaises(ValueError, cromwell_tools.validate_cromwell_label,
+                          json.dumps(self.invalid_labels).encode('utf-8'))
+
+    def test_validate_cromwell_label_on_valid_labels_object(self):
+        self.assertIsNone(cromwell_tools.validate_cromwell_label(self.valid_labels))
+
+    def test_validate_cromwell_label_on_valid_labels_str_object(self):
+        self.assertIsNone(cromwell_tools.validate_cromwell_label(json.dumps(self.valid_labels)))
+
+    def test_validate_cromwell_label_on_valid_labels_bytes_object(self):
+        self.assertIsNone(cromwell_tools.validate_cromwell_label(json.dumps(self.valid_labels).encode('utf-8')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR enables Cromwell-tools to add the label(s) at submission time. 

Besides, it implements a Cromwell label validator to check the validity of the label(s) before hitting the Cromwell endpoint. 

The implementation is based on the Cromwell doc: https://cromwell.readthedocs.io/en/develop/Labels/ and the scala code base of Cromwell: https://github.com/broadinstitute/cromwell/blob/develop/core/src/main/scala/cromwell/core/labels/Label.scala