### PR TITLE
Use offical blessed package to control the version(700)

### DIFF
--- a/cromwell_tools/__init__.py
+++ b/cromwell_tools/__init__.py
@@ -1,0 +1,10 @@
+"""The pkg_resources module will try to get the right version through the setuptools_scm, which will try to
+detect the version of cromwell_tools package from any git tags, commit hash codes. This works if this Python package
+ is either installed from PyPI or installed via git directly."""
+
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ CLASSIFIERS = [
 
 setup(
     name='cromwell-tools',
-    version='1.0.1',
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     description='Utilities for interacting with the Cromwell workflow engine',
     classifiers=CLASSIFIERS,
     url='http://github.com/broadinstitute/cromwell-tools',
@@ -29,8 +30,10 @@ setup(
         'requests==2.18.4',
         'six==1.11.0',
         'oauth2client==4.1.2',
-        'tenacity==4.10.0'
+        'tenacity==4.10.0',
+        'setuptools_scm==2.0.0'
     ],
     scripts=['cromwell_tools/scripts/cromwell-tools'],
     include_package_data=True
 )
+git


### PR DESCRIPTION
This PR follows the [instruction](https://pypi.org/project/setuptools_scm/) to manage the version of Cromwell-tools. This will be not only necessary for Lira's `/version` endpoint but also important to maintain the versions of all of our dependencies.

So in other applications, we can now get the version by:
```python
import cromwell_tools

cromwell_tools.__version__
```
And we don't need to update the `setup.py` manually anymore, it will automatically grab the right git tag.

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [x] Considered generalizability beyond our own use case
