### PR TITLE
BUG: Allow workflows without labels to be executed with run

### DIFF
--- a/cromwell_tools/cromwell_tools.py
+++ b/cromwell_tools/cromwell_tools.py
@@ -153,7 +153,7 @@ def start_workflow(
 
     :return requests.Response response: HTTP response from cromwell.
     """
-    if validate_labels:
+    if validate_labels and label is not None:
         validate_cromwell_label(label)
 
     files = {


### PR DESCRIPTION
- Only validate labels when a label is passed, even if `validate_labels` is `True`
