### PR TITLE
ENH: Allow cromwell url to be saved in secrets file, harmonize naming…

### DIFF
--- a/cromwell_tools/scripts/cromwell-tools
+++ b/cromwell_tools/scripts/cromwell-tools
@@ -27,16 +27,11 @@ def _start_workflow(arguments):
     except AttributeError:
         inputs2_json = None
 
-    response = cromwell_tools.start_workflow(
-        wdl_file=wdl_file,
-        inputs_file=inputs_json,
-        inputs_file2=inputs2_json,
-        zip_file=dependencies_zip,
-        options_file=options_json,
-        url=arguments.cromwell_url + '/api/workflows/v1',
-        user=user,
-        password=password,
-    )
+    response = cromwell_tools.start_workflow(wdl_file=wdl_file, inputs_file=inputs_json,
+                                             options_file=options_json, inputs_file2=inputs2_json,
+                                             zip_file=dependencies_zip,
+                                             cromwell_url=arguments.cromwell_url + '/api/workflows/v1',
+                                             cromwell_user=user, cromwell_password=password)
     response.raise_for_status()  # determine if workflow succeeded
     print(response.json()['id'])
 
@@ -51,21 +46,19 @@ def main(arguments=None):
     if arguments.command == 'run':
         _start_workflow(arguments)
     elif arguments.command == 'wait':
-        cromwell_tools.wait_until_workflow_completes(
-            cromwell_url=arguments.cromwell_url,
-            workflow_ids=arguments.workflow_ids,
-            timeout_minutes=arguments.timeout_minutes,
-            poll_interval_seconds=arguments.poll_interval_seconds,
-            cromwell_user=arguments.username,
-            cromwell_password=arguments.password,
-            secrets_file=arguments.secrets_file
-        )
+        cromwell_tools.wait_until_workflow_completes(workflow_ids=arguments.workflow_ids,
+                                                     timeout_minutes=arguments.timeout_minutes,
+                                                     poll_interval_seconds=arguments.poll_interval_seconds,
+                                                     cromwell_url=arguments.cromwell_url,
+                                                     cromwell_user=arguments.username,
+                                                     cromwell_password=arguments.password,
+                                                     secrets_file=arguments.secrets_file)
     elif arguments.command == 'status':
-        user, password, = cromwell_tools.harmonize_credentials(
-            arguments.secrets_file, arguments.username, arguments.password)
+        user, password, url = cromwell_tools.harmonize_credentials(
+            arguments.secrets_file, arguments.username, arguments.password, arguments.cromwell_url)
         cromwell_tools.get_workflow_statuses(
             ids=arguments.workflow_ids,
-            cromwell_url=arguments.cromwell_url,
+            cromwell_url=url,
             cromwell_user=user,
             cromwell_password=password,
             secrets_file=arguments.secrets_file
@@ -91,7 +84,7 @@ if __name__ == '__main__':
     # cromwell url and security arguments apply to all sub-commands
     sub_commands = [run, wait, status]
     for p in sub_commands:
-        p.add_argument('-c', '--cromwell-url')
+        p.add_argument('-c', '--cromwell-url', default=None)
         p.add_argument('-u', '--username', default=None)
         p.add_argument('-p', '--password', default=None)
         p.add_argument('-s', '--secrets-file', default=None)

--- a/cromwell_tools/tests/test_cromwell_tools.py
+++ b/cromwell_tools/tests/test_cromwell_tools.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 import io
+import zipfile
+import tempfile
+import os
+import json
+
+from tenacity import stop_after_delay, stop_after_attempt
 import requests
 import requests_mock
 import unittest
@@ -9,11 +15,31 @@ try:
 except ImportError:
     # if python2
     import mock
+
 from cromwell_tools import cromwell_tools
-import zipfile
-import os
-import json
-from tenacity import stop_after_delay, stop_after_attempt
+
+temp_dir = tempfile.mkdtemp()
+secrets_file = temp_dir + 'fake_secrets.json'
+auth = {
+    "cromwell_url": "https://fake_url",
+    "cromwell_user": "fake_user",
+    "cromwell_password": "fake_password",
+}
+with open(secrets_file, 'w') as f:
+    json.dump(auth, f)
+
+auth_options = (
+    auth,
+    {"secrets_file": secrets_file}
+)
+
+
+def _get_url(auth_or_secrets):
+    try:
+        return auth_or_secrets["cromwell_url"]
+    except KeyError:
+        with open(auth_or_secrets["secrets_file"], "r") as f:
+            return json.load(f)["cromwell_url"]
 
 
 class TestUtils(unittest.TestCase):
@@ -21,8 +47,8 @@ class TestUtils(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Change to test directory, as tests may have been invoked from another dir
-        dir = os.path.abspath(os.path.dirname(__file__))
-        os.chdir(dir)
+        dir_ = os.path.abspath(os.path.dirname(__file__))
+        os.chdir(dir_)
         cls.invalid_labels = {
             "0-label-key-1": "0-label-value-1",
             "the-maximum-allowed-character-length-for-label-pairs-is-sixty-three":
@@ -60,12 +86,13 @@ class TestUtils(unittest.TestCase):
             return {'request': {'body': "content"}}
 
         # Check request actions
-        mock_request.post(self.url, json=_request_callback)
-        result = cromwell_tools.start_workflow(
-            self.wdl_file, self.inputs_file, self.url, self.options_file, self.inputs_file2, self.zip_file, self.user,
-            self.password, label=self.label)
-        self.assertEqual(result.status_code, 200)
-        self.assertEqual(result.headers.get('test'), 'header')
+        for auth_kwargs in auth_options:
+            mock_request.post(_get_url(auth_kwargs), json=_request_callback)
+            result = cromwell_tools.start_workflow(
+                self.wdl_file, self.inputs_file, self.options_file, self.inputs_file2,
+                self.zip_file, label=self.label, **auth_kwargs)
+            self.assertEqual(result.status_code, 200)
+            self.assertEqual(result.headers.get('test'), 'header')
 
     @requests_mock.mock()
     def test_start_workflow_retries_on_error(self, mock_request):
@@ -75,15 +102,16 @@ class TestUtils(unittest.TestCase):
             return {'status': 'error', 'message': 'Internal Server Error'}
 
         # Make the test complete faster by limiting the number of retries
-        cromwell_tools.start_workflow.retry.stop = stop_after_attempt(3)
+        cromwell_tools.start_workflow.retry.stop = stop_after_attempt(2)
 
         # Check request actions
-        mock_request.post(self.url, json=_request_callback)
-        with self.assertRaises(requests.HTTPError):
-            result = cromwell_tools.start_workflow(
-                self.wdl_file, self.inputs_file, self.url, self.options_file, self.inputs_file2, self.zip_file,
-                self.user, self.password, label=self.label)
-            self.assertNotEqual(mock_request.call_count, 1)
+        for auth_kwargs in auth_options:
+            mock_request.post(_get_url(auth_kwargs), json=_request_callback)
+            with self.assertRaises(requests.HTTPError):
+                _ = cromwell_tools.start_workflow(
+                    self.wdl_file, self.inputs_file, self.options_file, self.inputs_file2,
+                    self.zip_file, label=self.label, **auth_kwargs)
+                self.assertNotEqual(mock_request.call_count, 1)
 
         # Reset default retry value
         cromwell_tools.start_workflow.retry.stop = stop_after_delay(20)
@@ -92,21 +120,24 @@ class TestUtils(unittest.TestCase):
     @mock.patch('cromwell_tools.cromwell_tools.generate_auth_header_from_key_file')
     def test_start_workflow_in_cromwell_as_a_service(self, mock_request, mock_header):
         mock_header.return_value = {"Authorization": "bearer fake_token"}
+
         def _request_callback(request, context):
             context.status_code = 200
             context.headers['test'] = 'header'
             return {'request': {'body': "content"}}
 
         # Check request actions
-        mock_request.post(self.url, json=_request_callback)
-        result = cromwell_tools.start_workflow(
-            self.wdl_file, self.inputs_file, self.url, self.options_file, self.inputs_file2, self.zip_file,
-            caas_key=self.caas_key, label=self.label)
-        self.assertEqual(result.status_code, 200)
-        self.assertEqual(result.headers.get('test'), 'header')
+        for auth_kwargs in auth_options:
+            mock_request.post(_get_url(auth_kwargs), json=_request_callback)
+            result = cromwell_tools.start_workflow(self.wdl_file, self.inputs_file, self.options_file,
+                                                   self.inputs_file2, self.zip_file, cromwell_url=self.url,
+                                                   caas_key=self.caas_key, label=self.label)
+            self.assertEqual(result.status_code, 200)
+            self.assertEqual(result.headers.get('test'), 'header')
 
     @requests_mock.mock()
     def test_get_workflow_statuses(self, mock_request):
+
         def _request_callback(request, context):
             context.status_code = 200
             context.headers['test'] = 'header'
@@ -118,10 +149,12 @@ class TestUtils(unittest.TestCase):
             return {'status': 'Succeeded'}
 
         ids = ["01234"]
-        mock_request.post(self.url, json=_request_callback)
-        mock_request.get(self.url + '/api/workflows/v1/{}/status'.format(ids[0]), json=_request_callback_status)
-        result = cromwell_tools.get_workflow_statuses(ids, self.url, self.user, self.password)
-        self.assertIn('Succeeded', result)
+        for auth_kwargs in auth_options:
+            url = _get_url(auth_kwargs)
+            mock_request.post(url, json=_request_callback)
+            mock_request.get(url + '/api/workflows/v1/{}/status'.format(ids[0]), json=_request_callback_status)
+            result = cromwell_tools.get_workflow_statuses(ids, **auth_kwargs)
+            self.assertIn('Succeeded', result)
 
     @requests_mock.mock()
     @mock.patch('cromwell_tools.cromwell_tools.generate_auth_header_from_key_file')


### PR DESCRIPTION
Cromwell URL is inextricably linked to password and username, so it makes sense to store all of these data in a secrets file. 

- Allow url in secrets
- harmonize naming of `cromwell_url`, `cromwell_user`, `cromwell_password` and `secrets_file` across `cromwell_tools` functions
- improve testing to test both input streams (url, user, password vs secrets_file)
