### PR TITLE
Fix a bug with the /query API

### DIFF
--- a/cromwell_tools/cromwell_api.py
+++ b/cromwell_tools/cromwell_api.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 _failed_statuses = ('Failed', 'Aborted', 'Aborting')
 
-_cromwell_exclusive_query_keys = {'end', 'includeSubworkflows', 'start', 'submission'}
+_cromwell_exclusive_query_keys = {'end', 'includeSubworkflows', 'start', 'submission', 'page', 'pageSize'}
 
 _cromwell_inclusive_query_keys = {'additionalQueryResultFields', 'excludeLabelAnd', 'excludeLabelOr',
                                   'id', 'includeSubworkflows', 'label', 'labelor', 'name', 'status'}

--- a/cromwell_tools/tests/test_cromwell_api.py
+++ b/cromwell_tools/tests/test_cromwell_api.py
@@ -141,14 +141,18 @@ class TestAPI(unittest.TestCase):
         query_dict = {'status': 'Running',
                       'start': '2018-01-01T00:00:00.000Z',
                       'end': '2018-01-01T12:00:00.000Z',
-                      'label': {'Comment': 'test'}
+                      'label': {'Comment': 'test'},
+                      'page': 1,
+                      'pageSize': 10
                       }
 
         expect_params = [
             {'status': 'Running'},
             {'start': '2018-01-01T00:00:00.000Z'},
             {'end': '2018-01-01T12:00:00.000Z'},
-            {'label': 'Comment:test'}
+            {'label': 'Comment:test'},
+            {'page': '1'},
+            {'pageSize': '10'}
         ]
 
         six.assertCountEqual(self, CromwellAPI._compose_query_params(query_dict), expect_params)


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- Fix a bug that prevents generating correct pagination parameters for POST /query endpoint.
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Add `page` and `pageSize` as allowed exclusive query keys.
---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [x] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
