### PR TITLE
Add linting and drop support for Python 2.x

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+# We ignore the following PEP-8 styles:
+
+# E203  whitespace before ‘:’
+# E266  too many leading ‘#’ for block comment
+# E501  line too long (82 > 79 characters) (^)
+# W503  line break occurred before a binary operator
+# F841  local variable is assigned to but never used
+# W605  invalid escape sequence (causes false alarms around regex)
+
+# Note: (^) These checks can be disabled at the
+# line level using the # noqa special comment.
+# This possibility should be reserved for special cases.
+
+[flake8]
+ignore = E203, E266, E501, W503, F841, W605
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+    - id: black
+      language_version: python3.6
+      # Using args here is not recommended by Black:
+      # https://black.readthedocs.io/en/stable/version_control_integration.html
+      # But since we only have one argument here, and
+      # we don't force developers to use editor plugins,
+      # putting the args here seems to be fine
+      args: [./, --skip-string-normalization]
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.7
+    hooks:
+    -   id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
-language: minimal
-sudo: required
-services: docker
-matrix:
+language: python
+
+python:
+  - '3.6'
+
+install: "pip install -r requirements-test.txt"
+
+jobs:
   include:
-      - name: "Python 2.7.12"
-        script: cd cromwell_tools/tests && bash test.sh "python2"
-      - name: "Python 3.5.2"
-        script: cd cromwell_tools/tests && bash test.sh "python3"
+    # The linting test is fast and cheap so run it first
+    - stage: Linting Test
+      script: 
+        # Check Black code style compliance
+        - black ./ --skip-string-normalization --check
+        # Check PEP-8 compliance
+        - flake8
+
+    # The unit test is a bit more expensive so run it only
+    # if the linting test passes
+    - stage: Unit Test
+      sudo: required
+      services: docker
+      script: cd cromwell_tools/tests && bash test.sh
 
 notifications:
   slack:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,18 @@
-FROM ubuntu:16.04
+FROM python:3.6
 
 LABEL maintainer = "Mint Team <mintteam@broadinstitute.org>" \
   software = "cromwell-tools" \
   description = "python package and CLI for interacting with cromwell" \
   website = "https://github.com/broadinstitute/cromwell-tools.git"
 
-# Install required packages
-RUN apt-get update && apt-get upgrade -y && apt-get -y install --no-install-recommends --fix-missing \
-    python-pip \
-    python3-pip \
-    git
-
-# Install java 8
-RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get clean all
-
-# Download and expose womtool
-ADD https://github.com/broadinstitute/cromwell/releases/download/35/womtool-35.jar /usr/local/bin/womtool/womtool-35.jar
-ENV WOMTOOL /usr/local/bin/womtool/womtool-35.jar
-
-# Upgrade pip for Python2
+# Upgrade pip
 RUN pip install --upgrade pip
 RUN pip install wheel
 RUN pip install --upgrade setuptools
 
-# Upgrade pip3 for Python3
-RUN pip3 install -U setuptools
-RUN pip3 install -U pip
-RUN pip3 install wheel
-
-# Copy the whole module
+# Copy the source code
 WORKDIR /cromwell-tools
 COPY . .
 
-# Install dependencies(including those for testing)
-RUN pip2 install .[test]
-RUN pip3 install .[test]
+# Install dependencies(including those for testing) from the source code
+RUN pip install .[test]

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Overview
 This repo contains a cromwell_tools Python package, accessory scripts and IPython notebooks.
 
 The cromwell_tools Python package is designed to be a Python API and Command Line Tool for interacting with the `Cromwell <https://github.com/broadinstitute/cromwell>`_. with the following features:
-    - Python3 compatible. (Starting from v2.0.0, cromwell-tools will no longer support Python 2.7)
+    - Python3 compatible. (Starting from release v2.0.0, cromwell-tools will no longer support Python 2.7)
     - Consistency in authentication to work with Cromwell.
     - Consistency between API and CLI interfaces.
     - Sufficient test cases.

--- a/README.rst
+++ b/README.rst
@@ -5,13 +5,29 @@ Cromwell-tools
     :target: https://quay.io/repository/broadinstitute/cromwell-tools
     :alt: Container Build Status
     
-.. image:: https://travis-ci.org/broadinstitute/cromwell-tools.svg?branch=master
+.. image:: https://img.shields.io/travis/com/broadinstitute/cromwell-tools.svg?label=Unit%20Test%20on%20Travis%20CI%20&style=flat-square
     :target: https://travis-ci.org/broadinstitute/cromwell-tools
-    :alt: Test Status (Python2/3)
+    :alt: Unit Test Status
 
-.. image:: https://readthedocs.org/projects/cromwell-tools/badge/?version=latest
+.. image:: https://img.shields.io/readthedocs/cromwell-tools/latest.svg?label=ReadtheDocs%3A%20Latest&logo=Read%20the%20Docs&style=flat-square
     :target: http://cromwell-tools.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
+
+.. image:: https://img.shields.io/github/release/broadinstitute/cromwell-tools.svg?label=Latest%20Release&style=flat-square&colorB=green
+    :target: https://github.com/broadinstitute/cromwell-tools/releases
+    :alt: Latest Release
+
+.. image:: https://img.shields.io/github/license/broadinstitute/cromwell-tools.svg?style=flat-square
+    :target: https://img.shields.io/github/license/broadinstitute/cromwell-tools.svg?style=flat-square
+    :alt: License
+
+.. image:: https://img.shields.io/badge/python-3.6-green.svg?style=flat-square&logo=python&colorB=blue
+    :target: https://img.shields.io/badge/python-3.6-green.svg?style=flat-square&logo=python&colorB=blue
+    :alt: Language
+
+.. image:: https://img.shields.io/badge/Code%20Style-black-000000.svg?style=flat-square
+    :target: https://github.com/ambv/black
+    :alt: Code Style
 
 Overview
 ========
@@ -19,7 +35,7 @@ Overview
 This repo contains a cromwell_tools Python package, accessory scripts and IPython notebooks.
 
 The cromwell_tools Python package is designed to be a Python API and Command Line Tool for interacting with the `Cromwell <https://github.com/broadinstitute/cromwell>`_. with the following features:
-    - Python2/3 compatible.
+    - Python3 compatible. (Starting from v2.0.0, cromwell-tools will no longer support Python 2.7)
     - Consistency in authentication to work with Cromwell.
     - Consistency between API and CLI interfaces.
     - Sufficient test cases.
@@ -67,7 +83,7 @@ This package also installs a command line interface that mirrors the API and is 
 
     $> cromwell-tools -h
     usage: cromwell-tools [-h]
-                      {submit,wait,status,abort,release_hold,query,health,validate}
+                      {submit,wait,status,abort,release_hold,query,health}
                       ...
 
     positional arguments:
@@ -80,7 +96,6 @@ This package also installs a command line interface that mirrors the API and is 
         release_hold        release_hold help
         query               query help
         health              health help
-        validate            validate help
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -99,17 +114,9 @@ Run Tests with Docker
 Running the tests within docker image is the recommended way, to do this, you need to have docker-daemon installed
 in your environment. From the root of the cromwell-tools repo:
 
-- Testing with Python 2.7, run:
-
 .. code::
 
-    cd cromwell_tools/tests && bash test.sh "python2"
-
-- Testing with Python 3.5, run:
-
-.. code::
-
-    cd cromwell_tools/tests && bash test.sh "python3"
+    cd cromwell_tools/tests && bash test.sh
 
 
 Run Tests with local Python environment
@@ -122,16 +129,6 @@ Run Tests with local Python environment
     virtualenv test-env
     source test-env/bin/activate
     pip install -r requirements.txt -r requirements-test.txt
-
-- Besides, the ``validate`` command of cromwell-tools requires you specify the path to the
-  `womtool.jar <https://github.com/broadinstitute/cromwell/tree/master/womtool>`_ so if you are running the tests
-  without using the docker image, you have to export the path to the womtool as an environment variable as follows,
-  otherwise the test suite will skip running the tests for ``validate``!
-
-.. code::
-
-    export WOMTOOL="/path/to/the/womtool/womtool-35.jar"
-
 
 - Finally, from the root of the cromwell-tools repo, run the tests with:
 
@@ -148,5 +145,22 @@ Run Tests with local Python environment
 Development
 ===========
 
-When upgrading the dependencies of cromwell-tools, please make sure ``requirements.txt``, ``requirements-test.txt``
-and ``setup.py`` are consistent!
+Code Style
+----------
+The cromwell-tools code base is complying with the PEP-8 and using `Black <https://github.com/ambv/black>`_ to
+format our code, in order to avoid "nitpicky" comments during the code review process so we spend more time discussing about the logic, 
+not code styles.
+
+In order to enable the auto-formatting in the development process, you have to spend a few seconds setting 
+up the ``pre-commit`` the first time you clone the repo:
+
+1. Install ``pre-commit`` by running: ``pip install pre-commit`` (or simply run ``pip install -r requirements.txt``).
+2. Run `pre-commit install` to install the git hook.
+
+Once you successfully install the ``pre-commit`` hook to this repo, the Black linter/formatter will be automatically triggered and run on this repo. Please make sure you followed the above steps, otherwise your commits might fail at the linting test!
+
+If you really want to manually trigger the linters and formatters on your code, make sure ``Black`` and ``flake8`` are installed in your Python environment and run ``flake8 DIR1 DIR2`` and ``black DIR1 DIR2 --skip-string-normalization`` respectively.
+
+Dependencies
+------------
+When upgrading the dependencies of cromwell-tools, please make sure ``requirements.txt``, ``requirements-test.txt`` and ``setup.py`` are consistent!

--- a/cromwell_tools/__init__.py
+++ b/cromwell_tools/__init__.py
@@ -5,6 +5,7 @@ is either installed from PyPI or installed via git directly.
 """
 
 from pkg_resources import get_distribution, DistributionNotFound
+
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
@@ -16,4 +17,4 @@ except DistributionNotFound:
 # cromwell_tools.api.metadata
 # cromwell_tools.api.run
 # ...
-from cromwell_tools.cromwell_api import CromwellAPI as api
+from cromwell_tools.cromwell_api import CromwellAPI as api  # noqa

--- a/cromwell_tools/cli.py
+++ b/cromwell_tools/cli.py
@@ -13,120 +13,166 @@ def parser(arguments=None):
 
     # sub-commands of cromwell-tools
     submit = subparsers.add_parser(
-            'submit', help='submit help', description='Submit a WDL workflow on Cromwell.')
+        'submit', help='submit help', description='Submit a WDL workflow on Cromwell.'
+    )
     wait = subparsers.add_parser(
-            'wait', help='wait help', description='Wait for one or more running workflow to finish.')
+        'wait',
+        help='wait help',
+        description='Wait for one or more running workflow to finish.',
+    )
     status = subparsers.add_parser(
-            'status', help='status help', description='Get the status of one or more workflows.')
+        'status',
+        help='status help',
+        description='Get the status of one or more workflows.',
+    )
     abort = subparsers.add_parser(
-            'abort', help='abort help', description='Request Cromwell to abort a running workflow by UUID.')
+        'abort',
+        help='abort help',
+        description='Request Cromwell to abort a running workflow by UUID.',
+    )
     release_hold = subparsers.add_parser(
-            'release_hold', help='release_hold help', description='Request Cromwell to release the hold on a workflow.')
+        'release_hold',
+        help='release_hold help',
+        description='Request Cromwell to release the hold on a workflow.',
+    )
     query = subparsers.add_parser(
-            'query', help='query help', description='[NOT IMPLEMENTED IN CLI] Query for workflows.')
+        'query',
+        help='query help',
+        description='[NOT IMPLEMENTED IN CLI] Query for workflows.',
+    )
     health = subparsers.add_parser(
-            'health', help='health help',
-            description='Check that cromwell is running and that provided authentication is valid.')
+        'health',
+        help='health help',
+        description='Check that cromwell is running and that provided authentication is valid.',
+    )
 
     # cromwell url and authentication arguments apply to all sub-commands
     cromwell_sub_commands = (submit, wait, status, abort, release_hold, query, health)
     auth_args = {
         'url': 'The URL to the Cromwell server. e.g. "https://cromwell.server.org/"',
-        'username':  'Cromwell username for HTTPBasicAuth.',
+        'username': 'Cromwell username for HTTPBasicAuth.',
         'password': 'Cromwell password for HTTPBasicAuth.',
         'secrets_file': 'Path to the JSON file containing username, password, and url fields.',
-        'service_account_key': 'Path to the JSON key file for authenticating with CaaS.'
+        'service_account_key': 'Path to the JSON key file for authenticating with CaaS.',
     }
 
     def add_auth_args(subcommand_parser):
         for arg_dest, help_text in auth_args.items():
-            subcommand_parser.add_argument('--{arg}'.format(arg=arg_dest.replace('_', '-')),
-                                           dest=arg_dest,
-                                           default=None,
-                                           type=str,
-                                           help=help_text)
+            subcommand_parser.add_argument(
+                '--{arg}'.format(arg=arg_dest.replace('_', '-')),
+                dest=arg_dest,
+                default=None,
+                type=str,
+                help=help_text,
+            )
+
     # TODO: this should be a group which is called authentication
     for p in cromwell_sub_commands:
         add_auth_args(p)
 
     # submit arguments
-    submit.add_argument('-w',
-                        '--wdl-file',
-                        dest='wdl_file',
-                        type=str,
-                        required=True,
-                        help='Path to the workflow source file to submit for execution.')
-    submit.add_argument('-i',
-                        '--inputs_files',
-                        dest='inputs_files',
-                        nargs='+',
-                        type=str,
-                        required=True,
-                        help='Path(s) to the input file(s) containing input data in JSON format, separated by space.')
-    submit.add_argument('-d',
-                        '--deps-file',
-                        dest='dependencies',
-                        nargs='+',
-                        type=str,
-                        help='Path to the Zip file containing dependencies, or a list of raw dependency files to '
-                             'be zipped together separated by space.')
-    submit.add_argument('-o',
-                        '--options-file',
-                        dest='options_file',
-                        type=str,
-                        help='Path to the Cromwell configs JSON file.')
+    submit.add_argument(
+        '-w',
+        '--wdl-file',
+        dest='wdl_file',
+        type=str,
+        required=True,
+        help='Path to the workflow source file to submit for execution.',
+    )
+    submit.add_argument(
+        '-i',
+        '--inputs_files',
+        dest='inputs_files',
+        nargs='+',
+        type=str,
+        required=True,
+        help='Path(s) to the input file(s) containing input data in JSON format, separated by space.',
+    )
+    submit.add_argument(
+        '-d',
+        '--deps-file',
+        dest='dependencies',
+        nargs='+',
+        type=str,
+        help='Path to the Zip file containing dependencies, or a list of raw dependency files to '
+        'be zipped together separated by space.',
+    )
+    submit.add_argument(
+        '-o',
+        '--options-file',
+        dest='options_file',
+        type=str,
+        help='Path to the Cromwell configs JSON file.',
+    )
     # TODO: add a mutually exclusive group to make it easy to add labels for users
-    submit.add_argument('-l',
-                        '--label-file',
-                        dest='label_file',
-                        type=str,
-                        default=None,
-                        help='Path to the JSON file containing a collection of key/value pairs for workflow labels.')
-    submit.add_argument('-c',
-                        '--collection-name',
-                        dest='collection_name',
-                        type=str,
-                        default=None,
-                        help='Collection in SAM that the workflow should belong to, if use CaaS.')
-    submit.add_argument('--on-hold',
-                        dest='on_hold',
-                        type=bool,
-                        default=False,
-                        help='Whether to submit the workflow in "On Hold" status.')
-    submit.add_argument('--validate-labels',
-                        dest='validate_labels',
-                        type=bool,
-                        default=False,
-                        help='Whether to validate cromwell labels.')
+    submit.add_argument(
+        '-l',
+        '--label-file',
+        dest='label_file',
+        type=str,
+        default=None,
+        help='Path to the JSON file containing a collection of key/value pairs for workflow labels.',
+    )
+    submit.add_argument(
+        '-c',
+        '--collection-name',
+        dest='collection_name',
+        type=str,
+        default=None,
+        help='Collection in SAM that the workflow should belong to, if use CaaS.',
+    )
+    submit.add_argument(
+        '--on-hold',
+        dest='on_hold',
+        type=bool,
+        default=False,
+        help='Whether to submit the workflow in "On Hold" status.',
+    )
+    submit.add_argument(
+        '--validate-labels',
+        dest='validate_labels',
+        type=bool,
+        default=False,
+        help='Whether to validate cromwell labels.',
+    )
 
     # wait arguments
-    wait.add_argument('workflow_ids',
-                      nargs='+')
-    wait.add_argument('--timeout-minutes',
-                      dest='timeout_minutes',
-                      type=int,
-                      default=120,
-                      help='number of minutes to wait before timeout')
-    wait.add_argument('--poll-interval-seconds',
-                      dest='poll_interval_seconds',
-                      type=int,
-                      default=30,
-                      help='seconds between polling cromwell for workflow status')
+    wait.add_argument('workflow_ids', nargs='+')
+    wait.add_argument(
+        '--timeout-minutes',
+        dest='timeout_minutes',
+        type=int,
+        default=120,
+        help='number of minutes to wait before timeout',
+    )
+    wait.add_argument(
+        '--poll-interval-seconds',
+        dest='poll_interval_seconds',
+        type=int,
+        default=30,
+        help='seconds between polling cromwell for workflow status',
+    )
 
     # status arguments
-    status.add_argument('--uuid',
-                        required=True,
-                        help='A Cromwell workflow UUID, which is the workflow identifier.')
+    status.add_argument(
+        '--uuid',
+        required=True,
+        help='A Cromwell workflow UUID, which is the workflow identifier.',
+    )
 
     # abort arguments
-    abort.add_argument('--uuid',
-                       required=True,
-                       help='A Cromwell workflow UUID, which is the workflow identifier.')
+    abort.add_argument(
+        '--uuid',
+        required=True,
+        help='A Cromwell workflow UUID, which is the workflow identifier.',
+    )
 
     # release_hold arguments
-    release_hold.add_argument('--uuid',
-                              required=True,
-                              help='A Cromwell workflow UUID, which is the workflow identifier.')
+    release_hold.add_argument(
+        '--uuid',
+        required=True,
+        help='A Cromwell workflow UUID, which is the workflow identifier.',
+    )
 
     # query arguments
     # TODO: implement CLI entry for query API.
@@ -135,7 +181,14 @@ def parser(arguments=None):
     args = vars(main_parser.parse_args(arguments))
 
     # TODO: see if this can be moved or if the commands can be populated from above
-    if args['command'] in ('submit', 'wait', 'status', 'abort', 'release_hold', 'health'):
+    if args['command'] in (
+        'submit',
+        'wait',
+        'status',
+        'abort',
+        'release_hold',
+        'health',
+    ):
         auth_arg_dict = {k: args.get(k) for k in auth_args.keys()}
         auth = CromwellAuth.harmonize_credentials(**auth_arg_dict)
         args['auth'] = auth

--- a/cromwell_tools/cli.py
+++ b/cromwell_tools/cli.py
@@ -27,8 +27,6 @@ def parser(arguments=None):
     health = subparsers.add_parser(
             'health', help='health help',
             description='Check that cromwell is running and that provided authentication is valid.')
-    validate = subparsers.add_parser(
-        'validate', help='validate help', description='Validate a cromwell workflow using womtool.')
 
     # cromwell url and authentication arguments apply to all sub-commands
     cromwell_sub_commands = (submit, wait, status, abort, release_hold, query, health)
@@ -133,32 +131,14 @@ def parser(arguments=None):
     # query arguments
     # TODO: implement CLI entry for query API.
 
-    # validate arguments
-    validate.add_argument('-w',
-                          '--wdl-file',
-                          dest='wdl',
-                          type=str,
-                          required=True)
-    validate.add_argument('--womtool-path',
-                          dest='womtool_path',
-                          type=str,
-                          required=True,
-                          help='path to cromwell womtool jar')
-    validate.add_argument('--dependencies-json',
-                          dest='dependencies_json',
-                          type=str,
-                          default=None)
-
     # group all of the arguments
     args = vars(main_parser.parse_args(arguments))
 
     # TODO: see if this can be moved or if the commands can be populated from above
-    if args['command'] in ('submit', 'wait', 'status', 'abort', 'release_hold', 'health', 'validate'):
-        if args['command'] == 'validate': args['command'] = 'validate_workflow'
-        else:
-            auth_arg_dict = {k: args.get(k) for k in auth_args.keys()}
-            auth = CromwellAuth.harmonize_credentials(**auth_arg_dict)
-            args['auth'] = auth
+    if args['command'] in ('submit', 'wait', 'status', 'abort', 'release_hold', 'health'):
+        auth_arg_dict = {k: args.get(k) for k in auth_args.keys()}
+        auth = CromwellAuth.harmonize_credentials(**auth_arg_dict)
+        args['auth'] = auth
         for k in auth_args:
             if k in args:
                 del args[k]

--- a/cromwell_tools/cromwell_api.py
+++ b/cromwell_tools/cromwell_api.py
@@ -418,32 +418,3 @@ class CromwellAPI(object):
         """
         if not response.ok:
             raise requests.exceptions.HTTPError('Error Code {0}: {1}'.format(response.status_code, response.text))
-
-    @classmethod
-    def validate_workflow(cls, wdl, womtool_path, dependencies_json=None):
-        """Validate a wdl workflow using cromwell womtool.
-
-        Args:
-            wdl (str): Link or file path to wdl file.
-            womtool_path (str): Path to the womtool.jar. For more details about what is a womtools,
-                see https://github.com/broadinstitute/cromwell/releases)
-            dependencies_json (str): File path to json file containing workflow dependencies.
-        """
-        temporary_directory = tempfile.mkdtemp()
-
-        _localize_file(wdl, temporary_directory)
-        wdl_basename = os.path.basename(wdl)
-
-        if dependencies_json is not None:
-            with open(dependencies_json, 'r') as f:
-                depenencies_map = json.load(f)
-            for url in depenencies_map.values():
-                _localize_file(url, temporary_directory)
-
-        os.chdir(temporary_directory)
-        p = Popen(['java', '-jar', os.path.expanduser(womtool_path), 'validate', wdl_basename],
-                  stdout=PIPE, stderr=PIPE)
-        out, err = p.communicate()
-        if err:
-            raise ChildProcessError(err)
-        print('stdout:\n%s' % out.decode())

--- a/cromwell_tools/cromwell_auth.py
+++ b/cromwell_tools/cromwell_auth.py
@@ -12,7 +12,6 @@ class AuthenticationError(Exception):
 
 
 class CromwellAuth:
-
     def __init__(self, url, header, auth, oauth_credentials=None):
         """Authentication Helper Class for a Cromwell Server.
 
@@ -71,17 +70,23 @@ class CromwellAuth:
             ValueError: when the header is not a valid header(with Bearer token).
         """
         if not header and not auth:
-            logging.warning('You are not using any authentication with Cromwell. For security purposes, '
-                            'please consider adding authentication in front of your Cromwell instance!')
+            logging.warning(
+                'You are not using any authentication with Cromwell. For security purposes, '
+                'please consider adding authentication in front of your Cromwell instance!'
+            )
 
         if header:
             if not isinstance(header, dict):
                 raise TypeError('If passed, header must be a dict.')
             if "authorization" not in [k.lower() for k in header.keys()]:
-                raise ValueError('The header must have an "Authorization" or "authorization" key!')
+                raise ValueError(
+                    'The header must have an "Authorization" or "authorization" key!'
+                )
 
         if auth and not isinstance(auth, requests.auth.HTTPBasicAuth):
-            raise TypeError('The auth object must be a valid "requests.auth.HTTPBasicAuth" object!')
+            raise TypeError(
+                'The auth object must be a valid "requests.auth.HTTPBasicAuth" object!'
+            )
 
     @staticmethod
     def _validate_url(url):
@@ -116,15 +121,15 @@ class CromwellAuth:
         Returns:
             CromwellAuth: An instance of this auth helper class with valid OAuth Auth header.
         """
-        scopes = [
-            'email',
-            'openid',
-            'profile'
-        ]
+        scopes = ['email', 'openid', 'profile']
         if isinstance(service_account_key, dict):
-            credentials = service_account.Credentials.from_service_account_info(service_account_key, scopes=scopes)
+            credentials = service_account.Credentials.from_service_account_info(
+                service_account_key, scopes=scopes
+            )
         else:
-            credentials = service_account.Credentials.from_service_account_file(service_account_key, scopes=scopes)
+            credentials = service_account.Credentials.from_service_account_file(
+                service_account_key, scopes=scopes
+            )
 
         if not credentials.valid:
             credentials.refresh(google.auth.transport.requests.Request())
@@ -149,10 +154,7 @@ class CromwellAuth:
         """
         with open(secrets_file, 'r') as f:
             secrets = json.load(f)
-        auth = requests.auth.HTTPBasicAuth(
-                secrets['username'],
-                secrets['password']
-        )
+        auth = requests.auth.HTTPBasicAuth(secrets['username'], secrets['password'])
         url = secrets['url']
         return cls(url=url, header=None, auth=auth)
 
@@ -185,7 +187,13 @@ class CromwellAuth:
 
     @classmethod
     def harmonize_credentials(
-            cls, username=None, password=None, url=None, secrets_file=None, service_account_key=None):
+        cls,
+        username=None,
+        password=None,
+        url=None,
+        secrets_file=None,
+        service_account_key=None,
+    ):
         """Parse and harmonize user inputted credentials and generate proper authentication object for cromwell-tools.
 
         Args:
@@ -210,12 +218,18 @@ class CromwellAuth:
             "service_account_key": all((service_account_key, url)),
             "secrets_file": True if secrets_file else False,
             "user_password": all((username, password, url)),
-            "no_auth": True if (not any((service_account_key, secrets_file, username, password)) and url) else False
+            "no_auth": True
+            if (
+                not any((service_account_key, secrets_file, username, password)) and url
+            )
+            else False,
         }
         if sum(credentials.values()) != 1:
             raise ValueError(
-                    "Exactly one set of credentials must be passed.\nCredentials: {}".format(
-                            repr(credentials)))
+                "Exactly one set of credentials must be passed.\nCredentials: {}".format(
+                    repr(credentials)
+                )
+            )
 
         if credentials["service_account_key"]:
             return cls.from_service_account_key_file(service_account_key, url)

--- a/cromwell_tools/tests/test.sh
+++ b/cromwell_tools/tests/test.sh
@@ -1,16 +1,7 @@
 #! /usr/bin/env bash
 
-# Usage: bash test.sh [python_version] where python_version is in {"python2", "python3"}
-# By default, it this script will run on python3
-
-python_version=${1:-"python3"}
-
 # note that this script can only be executed within the directory it lives in.
 docker build -t cromwell-tools:test ../..
 
 # Run unit tests in docker container
-if [ "$python_version" == "python2" ]; then
-  docker run cromwell-tools:test python2 -m pytest --cov=cromwell_tools cromwell_tools/tests
-else
-  docker run cromwell-tools:test python3 -m pytest --cov=cromwell_tools cromwell_tools/tests
-fi
+docker run cromwell-tools:test python -m pytest --cov=cromwell_tools cromwell_tools/tests

--- a/cromwell_tools/tests/test_cromwell_api.py
+++ b/cromwell_tools/tests/test_cromwell_api.py
@@ -307,42 +307,5 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(result.json()['status'], 'Succeeded')
 
 
-class TestValidate(unittest.TestCase):
-
-    def test_localize_file(self):
-        temporary_directory = tempfile.mkdtemp()
-
-        # test that we can localize both local and https files. Use this file as a convenient target
-        targets = [
-            'https://raw.githubusercontent.com/broadinstitute/cromwell-tools/v0.5.0/'
-            'cromwell_tools/tests/test_cromwell_tools.py',
-            __file__
-        ]
-        for target in targets:
-            utils._localize_file(target, temporary_directory)
-            localized_file = os.path.join(temporary_directory, os.path.basename(target))
-
-            # verify the file was localized and that it contains some expected content
-            assert os.path.isfile(localized_file)
-            with open(localized_file, 'r') as f:
-                assert 'cromwell_tools' in f.read()
-            os.remove(localized_file)
-
-    @unittest.skipIf(not os.environ.get('WOMTOOL'), 'Environment Variable WOMTOOL not found, cannot locate womtool.jar')
-    def test_validate_wdl(self):
-        # change dir so we can leverage relative paths to data
-        cwd = os.getcwd()
-        test_directory = os.path.dirname(__file__)
-        os.chdir(test_directory)
-
-        womtool = os.environ['WOMTOOL']
-        wdl = 'data/test_workflow.wdl'
-        dependencies_json = 'data/test_dependencies.json'
-        CromwellAPI.validate_workflow(wdl, womtool, dependencies_json)
-
-        # put the directory back how we found it
-        os.chdir(cwd)
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/cromwell_tools/tests/test_cromwell_auth.py
+++ b/cromwell_tools/tests/test_cromwell_auth.py
@@ -15,16 +15,15 @@ def setup_auth_types():
     password = "fake_password"
     url = "https://fake_url"
 
-    auth_params = {
-        "url": url,
-        "username": username,
-        "password": password
-    }
+    auth_params = {"url": url, "username": username, "password": password}
     with open(secrets_file, 'w') as f:
         json.dump(auth_params, f)
 
     auth_params['secrets_file'] = {"secrets_file": secrets_file}
-    auth_params['service_account_key'] = {"service_account_key": service_account_key, "url": url}
+    auth_params['service_account_key'] = {
+        "service_account_key": service_account_key,
+        "url": url,
+    }
     return auth_params
 
 
@@ -34,7 +33,9 @@ auth_types = setup_auth_types()
 @mock.patch('cromwell_tools.cromwell_auth.CromwellAuth.from_service_account_key_file')
 def test_harmonize_credentials_only_takes_one_auth_type(mock_header):
     url = 'https://cromwell.server.org'
-    expected_auth = CromwellAuth(url=url, header={"Authorization": "bearer fake_token"}, auth=None)
+    expected_auth = CromwellAuth(
+        url=url, header={"Authorization": "bearer fake_token"}, auth=None
+    )
     mock_header.return_value = expected_auth
     with pytest.raises(ValueError):
         CromwellAuth.harmonize_credentials(**auth_types)
@@ -44,8 +45,12 @@ def test_harmonize_credentials_user_password():
     username = 'fake_user'
     password = 'fake_password'
     url = 'https://cromwell.server.org'
-    expected_auth = CromwellAuth(url=url, header=None, auth=requests.auth.HTTPBasicAuth(username, password))
-    auth = CromwellAuth.harmonize_credentials(username=username, password=password, url=url)
+    expected_auth = CromwellAuth(
+        url=url, header=None, auth=requests.auth.HTTPBasicAuth(username, password)
+    )
+    auth = CromwellAuth.harmonize_credentials(
+        username=username, password=password, url=url
+    )
     assert auth.auth == expected_auth.auth
     assert auth.header == expected_auth.header
 
@@ -54,8 +59,12 @@ def test_harmonize_credentials_from_secrets_file():
     username = "fake_user"
     password = "fake_password"
     url = "https://fake_url"
-    expected_auth = CromwellAuth(url=url, header=None, auth=requests.auth.HTTPBasicAuth(username, password))
-    auth = CromwellAuth.harmonize_credentials(secrets_file=auth_types['secrets_file']['secrets_file'])
+    expected_auth = CromwellAuth(
+        url=url, header=None, auth=requests.auth.HTTPBasicAuth(username, password)
+    )
+    auth = CromwellAuth.harmonize_credentials(
+        secrets_file=auth_types['secrets_file']['secrets_file']
+    )
     assert auth.auth == expected_auth.auth
     assert auth.header == expected_auth.header
 
@@ -64,9 +73,13 @@ def test_harmonize_credentials_from_secrets_file():
 def test_harmonize_credentials_from_service_account_key(mock_header):
     service_account_key = 'fake_key.json'
     url = 'https://cromwell.server.org'
-    expected_auth = CromwellAuth(url=url, header={"Authorization": "bearer fake_token"}, auth=None)
+    expected_auth = CromwellAuth(
+        url=url, header={"Authorization": "bearer fake_token"}, auth=None
+    )
     mock_header.return_value = expected_auth
-    auth = CromwellAuth.harmonize_credentials(url=url, service_account_key=service_account_key)
+    auth = CromwellAuth.harmonize_credentials(
+        url=url, service_account_key=service_account_key
+    )
     assert auth == expected_auth
 
 
@@ -74,9 +87,13 @@ def test_harmonize_credentials_from_service_account_key(mock_header):
 def test_harmonize_credentials_from_service_account_key_content(mock_header):
     service_account_key = {'client_email': 'fake_email', 'token_uri': 'fake_uri'}
     url = 'https://cromwell.server.org'
-    expected_auth = CromwellAuth(url=url, header={"Authorization": "bearer fake_token"}, auth=None)
+    expected_auth = CromwellAuth(
+        url=url, header={"Authorization": "bearer fake_token"}, auth=None
+    )
     mock_header.return_value = expected_auth
-    auth = CromwellAuth.harmonize_credentials(url=url, service_account_key=service_account_key)
+    auth = CromwellAuth.harmonize_credentials(
+        url=url, service_account_key=service_account_key
+    )
     assert auth == expected_auth
 
 

--- a/cromwell_tools/tests/test_utilities.py
+++ b/cromwell_tools/tests/test_utilities.py
@@ -11,7 +11,7 @@ import zipfile
 
 six.add_move(six.MovedModule('mock', 'mock', 'unittest.mock'))
 
-from cromwell_tools import utilities as utils
+from cromwell_tools import utilities as utils  # noqa
 
 
 class TestUtilities(unittest.TestCase):
@@ -30,40 +30,49 @@ class TestUtilities(unittest.TestCase):
     def setUp(self):
         self.invalid_labels = {
             "0-label-key-1": "0-label-value-1",
-            "the-maximum-allowed-character-length-for-label-pairs-is-sixty-three":
-                "cromwell-please-dont-validate-these-labels",
+            "the-maximum-allowed-character-length-for-label-pairs-is-sixty-three": "cromwell-please-dont-validate-these-labels",
             "": "not a great label key",
-            "Comment": "This-is-a-test-label"
+            "Comment": "This-is-a-test-label",
         }
         self.valid_labels = {
             "label-key-1": "label-value-1",
             "label-key-2": "label-value-2",
             "only-key": "",
             "fc-id": "0123-abcd-4567-efgh",
-            "comment": "this-is-a-test-label"
+            "comment": "this-is-a-test-label",
         }
         self.wdl_file_path = 'data/test_workflow.wdl'
         self.wdl_file_BytesIO = self._load_test_data_as_BytesIO(self.wdl_file_path)
 
         self.inputs_file_path = 'data/test_inputs1.json'
-        self.inputs_file_BytesIO = self._load_test_data_as_BytesIO(self.inputs_file_path)
+        self.inputs_file_BytesIO = self._load_test_data_as_BytesIO(
+            self.inputs_file_path
+        )
 
-        self.inputs_file_path_list = ['data/test_inputs1.json', 'data/test_inputs2.json']
-        self.inputs_file_BytesIO_list = [self._load_test_data_as_BytesIO(f) for f in self.inputs_file_path_list]
+        self.inputs_file_path_list = [
+            'data/test_inputs1.json',
+            'data/test_inputs2.json',
+        ]
+        self.inputs_file_BytesIO_list = [
+            self._load_test_data_as_BytesIO(f) for f in self.inputs_file_path_list
+        ]
 
         self.options_file_path = 'data/test_options.json'
-        self.options_file_BytesIO = self._load_test_data_as_BytesIO(self.options_file_path)
+        self.options_file_BytesIO = self._load_test_data_as_BytesIO(
+            self.options_file_path
+        )
 
         self.label_file_path = 'data/test_labels.json'
         self.label_file_BytesIO = self._load_test_data_as_BytesIO(self.label_file_path)
 
         self.deps_zip_file_path = 'data/test_deps.zip'
         self.deps_files_paths_list = ['data/test_task.wdl']
-        self.deps_zip_file_BytesIO = self._load_test_data_as_BytesIO(self.deps_zip_file_path)
+        self.deps_zip_file_BytesIO = self._load_test_data_as_BytesIO(
+            self.deps_zip_file_path
+        )
 
     @requests_mock.mock()
     def test_download_http_raises_error_on_bad_status_code(self, mock_request):
-
         def _request_callback(request, context):
             context.status_code = 404
             return 'Not found'
@@ -76,7 +85,6 @@ class TestUtilities(unittest.TestCase):
 
     @requests_mock.mock()
     def test_download_http_no_error_on_200(self, mock_request):
-
         def _request_callback(request, context):
             context.status_code = 200
             return 'foo'
@@ -91,7 +99,6 @@ class TestUtilities(unittest.TestCase):
 
     @requests_mock.mock()
     def test_download_http_no_error_on_301(self, mock_request):
-
         def _request_callback(request, context):
             context.status_code = 301
             return 'foo'
@@ -121,7 +128,7 @@ class TestUtilities(unittest.TestCase):
         # make_zip_in_memory.
         urls_to_content = {
             'data/a.txt': 'aaa\n'.encode('utf-8'),
-            'data/b.txt': 'bbb\n'.encode('utf-8')
+            'data/b.txt': 'bbb\n'.encode('utf-8'),
         }
         bytes_buf = utils.make_zip_in_memory(urls_to_content)
         with zipfile.ZipFile(bytes_buf, 'r') as zf:
@@ -133,16 +140,21 @@ class TestUtilities(unittest.TestCase):
         self.assertEqual(f2_contents, b'bbb\n')
 
     def test_validate_cromwell_label_on_invalid_labels_object(self):
-        self.assertRaises(ValueError, utils.validate_cromwell_label,
-                          self.invalid_labels)
+        self.assertRaises(
+            ValueError, utils.validate_cromwell_label, self.invalid_labels
+        )
 
     def test_validate_cromwell_label_on_invalid_labels_str_object(self):
-        self.assertRaises(ValueError, utils.validate_cromwell_label,
-                          json.dumps(self.invalid_labels))
+        self.assertRaises(
+            ValueError, utils.validate_cromwell_label, json.dumps(self.invalid_labels)
+        )
 
     def test_validate_cromwell_label_on_invalid_labels_bytes_object(self):
-        self.assertRaises(ValueError, utils.validate_cromwell_label,
-                          json.dumps(self.invalid_labels).encode('utf-8'))
+        self.assertRaises(
+            ValueError,
+            utils.validate_cromwell_label,
+            json.dumps(self.invalid_labels).encode('utf-8'),
+        )
 
     def test_validate_cromwell_label_on_valid_labels_object(self):
         self.assertIsNone(utils.validate_cromwell_label(self.valid_labels))
@@ -151,14 +163,18 @@ class TestUtilities(unittest.TestCase):
         self.assertIsNone(utils.validate_cromwell_label(json.dumps(self.valid_labels)))
 
     def test_validate_cromwell_label_on_valid_labels_bytes_object(self):
-        self.assertIsNone(utils.validate_cromwell_label(json.dumps(self.valid_labels).encode('utf-8')))
+        self.assertIsNone(
+            utils.validate_cromwell_label(json.dumps(self.valid_labels).encode('utf-8'))
+        )
 
     def test_localize_file(self):
         temporary_directory = tempfile.mkdtemp()
         # test that we can localize both local and https files. Use this file as a convenient target
-        targets = ('https://raw.githubusercontent.com/broadinstitute/cromwell-tools/'
-                   'v0.5.0/cromwell_tools/tests/test_cromwell_tools.py', 
-                   __file__)
+        targets = (
+            'https://raw.githubusercontent.com/broadinstitute/cromwell-tools/'
+            'v0.5.0/cromwell_tools/tests/test_cromwell_tools.py',
+            __file__,
+        )
         for target in targets:
             utils._localize_file(target, temporary_directory)
             localized_file = os.path.join(temporary_directory, os.path.basename(target))
@@ -173,94 +189,142 @@ class TestUtilities(unittest.TestCase):
         manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path)
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowSource'].getvalue() == expected_manifest['workflowSource'].getvalue()
+        assert (
+            manifest['workflowSource'].getvalue()
+            == expected_manifest['workflowSource'].getvalue()
+        )
 
     def test_prepare_workflow_manifest_works_for_wdl_file_with_BytesIO(self):
         manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_BytesIO)
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowSource'].getvalue() == expected_manifest['workflowSource'].getvalue()
+        assert (
+            manifest['workflowSource'].getvalue()
+            == expected_manifest['workflowSource'].getvalue()
+        )
 
     def test_prepare_workflow_manifest_works_for_one_inputs_file_with_filepath(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   inputs_files=self.inputs_file_path)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, inputs_files=self.inputs_file_path
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowInputs': self.inputs_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowInputs'].getvalue() == expected_manifest['workflowInputs'].getvalue()
+        assert (
+            manifest['workflowInputs'].getvalue()
+            == expected_manifest['workflowInputs'].getvalue()
+        )
 
     def test_prepare_workflow_manifest_works_for_one_inputs_file_with_BytesIO(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   inputs_files=self.inputs_file_BytesIO)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, inputs_files=self.inputs_file_BytesIO
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowInputs': self.inputs_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowInputs'].getvalue() == expected_manifest['workflowInputs'].getvalue()
+        assert (
+            manifest['workflowInputs'].getvalue()
+            == expected_manifest['workflowInputs'].getvalue()
+        )
 
-    def test_prepare_workflow_manifest_works_for_multiple_inputs_files_with_filepath(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   inputs_files=self.inputs_file_path_list)
+    def test_prepare_workflow_manifest_works_for_multiple_inputs_files_with_filepath(
+        self
+    ):
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, inputs_files=self.inputs_file_path_list
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowInputs': self.inputs_file_BytesIO_list[0],
             'workflowInputs_2': self.inputs_file_BytesIO_list[1],
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowInputs'].getvalue() == expected_manifest['workflowInputs'].getvalue()
-        assert manifest['workflowInputs_2'].getvalue() == expected_manifest['workflowInputs_2'].getvalue()
+        assert (
+            manifest['workflowInputs'].getvalue()
+            == expected_manifest['workflowInputs'].getvalue()
+        )
+        assert (
+            manifest['workflowInputs_2'].getvalue()
+            == expected_manifest['workflowInputs_2'].getvalue()
+        )
 
-    def test_prepare_workflow_manifest_works_for_multiple_inputs_files_with_BytesIO(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   inputs_files=self.inputs_file_BytesIO_list)
+    def test_prepare_workflow_manifest_works_for_multiple_inputs_files_with_BytesIO(
+        self
+    ):
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, inputs_files=self.inputs_file_BytesIO_list
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowInputs': self.inputs_file_BytesIO_list[0],
             'workflowInputs_2': self.inputs_file_BytesIO_list[1],
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowInputs'].getvalue() == expected_manifest['workflowInputs'].getvalue()
-        assert manifest['workflowInputs_2'].getvalue() == expected_manifest['workflowInputs_2'].getvalue()
+        assert (
+            manifest['workflowInputs'].getvalue()
+            == expected_manifest['workflowInputs'].getvalue()
+        )
+        assert (
+            manifest['workflowInputs_2'].getvalue()
+            == expected_manifest['workflowInputs_2'].getvalue()
+        )
 
     def test_prepare_workflow_manifest_works_for_dependencies_file_with_filepath(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   dependencies=self.deps_zip_file_path)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, dependencies=self.deps_zip_file_path
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowDependencies': self.deps_zip_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowDependencies'].getvalue() == expected_manifest['workflowDependencies'].getvalue()
+        assert (
+            manifest['workflowDependencies'].getvalue()
+            == expected_manifest['workflowDependencies'].getvalue()
+        )
 
-    def test_prepare_workflow_manifest_raises_an_error_for_dependencies_file_with_filepath_not_pointing_to_zip(self):
+    def test_prepare_workflow_manifest_raises_an_error_for_dependencies_file_with_filepath_not_pointing_to_zip(
+        self
+    ):
         with self.assertRaises(ValueError):
-            utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                            dependencies="data/fake_test_deps.wdl")
-    
-    def test_prepare_workflow_manifest_works_for_dependencies_file_with_filepath_in_a_list(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   dependencies=[self.deps_zip_file_path])
-        expected_manifest = {
-            'workflowSource': self.wdl_file_BytesIO,
-            'workflowDependencies': self.deps_zip_file_BytesIO,
-            'workflowOnHold': 'false'
-        }
-        assert manifest['workflowDependencies'].getvalue() == expected_manifest['workflowDependencies'].getvalue()
+            utils.prepare_workflow_manifest(
+                wdl_file=self.wdl_file_path, dependencies="data/fake_test_deps.wdl"
+            )
 
-    def test_prepare_workflow_manifest_works_for_dependencies_file_with_list_of_files(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   dependencies=self.deps_files_paths_list)
+    def test_prepare_workflow_manifest_works_for_dependencies_file_with_filepath_in_a_list(
+        self
+    ):
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, dependencies=[self.deps_zip_file_path]
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowDependencies': self.deps_zip_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
+        }
+        assert (
+            manifest['workflowDependencies'].getvalue()
+            == expected_manifest['workflowDependencies'].getvalue()
+        )
+
+    def test_prepare_workflow_manifest_works_for_dependencies_file_with_list_of_files(
+        self
+    ):
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, dependencies=self.deps_files_paths_list
+        )
+        expected_manifest = {
+            'workflowSource': self.wdl_file_BytesIO,
+            'workflowDependencies': self.deps_zip_file_BytesIO,
+            'workflowOnHold': 'false',
         }
         with zipfile.ZipFile(manifest['workflowDependencies'], 'r') as zf:
             with zf.open('test_task.wdl') as dep_file:
@@ -274,70 +338,94 @@ class TestUtilities(unittest.TestCase):
         assert contents.getvalue() == expected_contents.getvalue()
 
     def test_prepare_workflow_manifest_works_for_dependencies_file_with_BytesIO(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   dependencies=self.deps_zip_file_BytesIO)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, dependencies=self.deps_zip_file_BytesIO
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowDependencies': self.deps_zip_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowDependencies'].getvalue() == expected_manifest['workflowDependencies'].getvalue()
+        assert (
+            manifest['workflowDependencies'].getvalue()
+            == expected_manifest['workflowDependencies'].getvalue()
+        )
 
     def test_prepare_workflow_manifest_works_for_collection_name(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path, collection_name='test_collection')
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, collection_name='test_collection'
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'collectionName': 'test_collection',
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowSource'].getvalue() == expected_manifest['workflowSource'].getvalue()
+        assert (
+            manifest['workflowSource'].getvalue()
+            == expected_manifest['workflowSource'].getvalue()
+        )
         assert manifest['collectionName'] == expected_manifest['collectionName']
 
     def test_prepare_workflow_manifest_works_for_on_hold(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path, on_hold=True)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, on_hold=True
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
-            'workflowOnHold': 'true'
+            'workflowOnHold': 'true',
         }
-        assert manifest['workflowSource'].getvalue() == expected_manifest['workflowSource'].getvalue()
+        assert (
+            manifest['workflowSource'].getvalue()
+            == expected_manifest['workflowSource'].getvalue()
+        )
         assert manifest['workflowOnHold'] == expected_manifest['workflowOnHold']
 
     def test_prepare_workflow_manifest_works_for_label_file_with_filepath(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   label_file=self.label_file_path)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, label_file=self.label_file_path
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'labels': self.label_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
         assert manifest['labels'].getvalue() == expected_manifest['labels'].getvalue()
 
     def test_prepare_workflow_manifest_works_for_label_file_with_BytesIO(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   label_file=self.label_file_BytesIO)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, label_file=self.label_file_BytesIO
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'labels': self.label_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
         assert manifest['labels'].getvalue() == expected_manifest['labels'].getvalue()
 
     def test_prepare_workflow_manifest_works_for_options_file_with_filepath(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   options_file=self.options_file_path)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, options_file=self.options_file_path
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowOptions': self.options_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowOptions'].getvalue() == expected_manifest['workflowOptions'].getvalue()
+        assert (
+            manifest['workflowOptions'].getvalue()
+            == expected_manifest['workflowOptions'].getvalue()
+        )
 
     def test_prepare_workflow_manifest_works_for_options_file_with_BytesIO(self):
-        manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path,
-                                                   options_file=self.options_file_BytesIO)
+        manifest = utils.prepare_workflow_manifest(
+            wdl_file=self.wdl_file_path, options_file=self.options_file_BytesIO
+        )
         expected_manifest = {
             'workflowSource': self.wdl_file_BytesIO,
             'workflowOptions': self.options_file_BytesIO,
-            'workflowOnHold': 'false'
+            'workflowOnHold': 'false',
         }
-        assert manifest['workflowOptions'].getvalue() == expected_manifest['workflowOptions'].getvalue()
+        assert (
+            manifest['workflowOptions'].getvalue()
+            == expected_manifest['workflowOptions'].getvalue()
+        )

--- a/cromwell_tools/tests/test_utilities.py
+++ b/cromwell_tools/tests/test_utilities.py
@@ -153,18 +153,21 @@ class TestUtilities(unittest.TestCase):
     def test_validate_cromwell_label_on_valid_labels_bytes_object(self):
         self.assertIsNone(utils.validate_cromwell_label(json.dumps(self.valid_labels).encode('utf-8')))
 
-    def test_localize_file_https(self):
+    def test_localize_file(self):
         temporary_directory = tempfile.mkdtemp()
-        # grab this file from the master branch of the cromwell-tools repository
-        target = ('https://raw.githubusercontent.com/broadinstitute/cromwell-tools/'
-                  'v0.3.1/cromwell_tools/tests/test_cromwell_tools.py')
-        utils._localize_file(target, temporary_directory)
-        localized_file = os.path.join(temporary_directory, os.path.basename(target))
+        # test that we can localize both local and https files. Use this file as a convenient target
+        targets = ('https://raw.githubusercontent.com/broadinstitute/cromwell-tools/'
+                   'v0.5.0/cromwell_tools/tests/test_cromwell_tools.py', 
+                   __file__)
+        for target in targets:
+            utils._localize_file(target, temporary_directory)
+            localized_file = os.path.join(temporary_directory, os.path.basename(target))
 
-        # verify the file was downloaded and that it contains some content we expect
-        assert os.path.isfile(localized_file)
-        with open(localized_file, 'r') as f:
-            assert 'cromwell_tools' in f.read()
+            # verify the file was downloaded and that it contains some content we expect
+            assert os.path.isfile(localized_file)
+            with open(localized_file, 'r') as f:
+                assert 'cromwell_tools' in f.read()
+            os.remove(localized_file)
 
     def test_prepare_workflow_manifest_works_for_wdl_file_with_filepath(self):
         manifest = utils.prepare_workflow_manifest(wdl_file=self.wdl_file_path)

--- a/cromwell_tools/utilities.py
+++ b/cromwell_tools/utilities.py
@@ -40,7 +40,7 @@ def _emulate_python_fullmatch(regex, string, flags=0):
     return re.match("(?:" + regex + r")\Z", string, flags=flags)
 
 
-if not "fullmatch" in dir(re):  # For Python3.4+
+if "fullmatch" not in dir(re):  # For Python3.4+
     re.fullmatch = _emulate_python_fullmatch
 
 
@@ -150,7 +150,8 @@ def _localize_file(url, target_directory='.'):
     """
     if not os.path.isdir(target_directory):
         raise NotADirectoryError(
-            'target_directory must be a valid directory on the local filesystem')
+            'target_directory must be a valid directory on the local filesystem'
+        )
 
     basename = os.path.basename(url)
     target_file = os.path.join(target_directory, basename)
@@ -162,7 +163,10 @@ def _localize_file(url, target_directory='.'):
     else:
         if not os.path.isfile(url):
             raise FileNotFoundError(
-                'non-http files must point to a valid file on the local filesystem. Not found: {}'.format(url))
+                'non-http files must point to a valid file on the local filesystem. Not found: {}'.format(
+                    url
+                )
+            )
         else:
             shutil.copy(url, target_file)
 
@@ -180,7 +184,9 @@ def _content_checker(regex, content):
     matched = re.fullmatch(regex, content)
 
     if not matched:
-        return 'Invalid label: {0} did not match the regex {1}.\n'.format(content, regex)
+        return 'Invalid label: {0} did not match the regex {1}.\n'.format(
+            content, regex
+        )
     else:
         return ''
 
@@ -196,7 +202,9 @@ def _length_checker(length, content):
         str: A string of error message if validation fails, or an empty string if validation succeeds.
     """
     if len(content) > length:
-        return 'Invalid label: {0} has {1} characters. The maximum is {2}.\n'.format(content, len(content), length)
+        return 'Invalid label: {0} has {1} characters. The maximum is {2}.\n'.format(
+            content, len(content), length
+        )
     else:
         return ''
 
@@ -217,9 +225,12 @@ def validate_cromwell_label(label_object):
     Raises:
         ValueError: This validator will raise an exception if the label_object is invalid as a Cromwell label.
     """
-    warnings.warn("This function doesn't work for Cromwell v32 and later versions and has been deprecated, "
-                  "be aware of using this validator when using Cromwell v32(+). Check "
-                  "https://cromwell.readthedocs.io/en/stable/Labels/ for details.", PendingDeprecationWarning)
+    warnings.warn(
+        "This function doesn't work for Cromwell v32 and later versions and has been deprecated, "
+        "be aware of using this validator when using Cromwell v32(+). Check "
+        "https://cromwell.readthedocs.io/en/stable/Labels/ for details.",
+        PendingDeprecationWarning,
+    )
 
     err_msg = ''
 
@@ -240,8 +251,15 @@ def validate_cromwell_label(label_object):
         raise ValueError(err_msg)
 
 
-def prepare_workflow_manifest(wdl_file, inputs_files=None, options_file=None, dependencies=None, label_file=None,
-                              collection_name=None, on_hold=False):
+def prepare_workflow_manifest(
+    wdl_file,
+    inputs_files=None,
+    options_file=None,
+    dependencies=None,
+    label_file=None,
+    collection_name=None,
+    on_hold=False,
+):
     """Prepare the submission manifest for a workflow submission.
 
     Args:
@@ -285,13 +303,17 @@ def prepare_workflow_manifest(wdl_file, inputs_files=None, options_file=None, de
                 input_file_key = 'workflowInputs'
             else:
                 # Compose other WDL inputs (from 2 - many)
-                input_file_key = 'workflowInputs_{X}'.format(X=idx+1)
+                input_file_key = 'workflowInputs_{X}'.format(X=idx + 1)
 
-            workflow_manifest[input_file_key] = _download_to_BytesIO_if_string(inputs_file)
+            workflow_manifest[input_file_key] = _download_to_BytesIO_if_string(
+                inputs_file
+            )
 
     # Compose WDL options
     if options_file:
-        workflow_manifest['workflowOptions'] = _download_to_BytesIO_if_string(options_file)
+        workflow_manifest['workflowOptions'] = _download_to_BytesIO_if_string(
+            options_file
+        )
 
     # Compose WDL labels
     if label_file:
@@ -308,7 +330,9 @@ def prepare_workflow_manifest(wdl_file, inputs_files=None, options_file=None, de
                 zip_file = make_zip_in_memory(download_to_map(dependencies))
         elif isinstance(dependencies, str) and not dependencies.endswith('.zip'):
             # when a single file is provided as a string but not zipped
-            raise ValueError('The dependency file path must point to a ".zip" file! Or you may want to provide a list of WDL file(s).')
+            raise ValueError(
+                'The dependency file path must point to a ".zip" file! Or you may want to provide a list of WDL file(s).'
+            )
         else:
             # when a single zip file is provided as a string
             zip_file = _download_to_BytesIO_if_string(dependencies)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -88,9 +88,7 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {
-    'navigation_depth': 4,
-}
+html_theme_options = {'navigation_depth': 4}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -120,15 +118,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -138,8 +133,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Cromwell-tools.tex', 'Cromwell-tools Documentation',
-     'Mint Team', 'manual'),
+    (
+        master_doc,
+        'Cromwell-tools.tex',
+        'Cromwell-tools Documentation',
+        'Mint Team',
+        'manual',
+    )
 ]
 
 
@@ -148,8 +148,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'cromwell-tools', 'Cromwell-tools Documentation',
-     [author], 1)
+    (master_doc, 'cromwell-tools', 'Cromwell-tools Documentation', [author], 1)
 ]
 
 
@@ -159,9 +158,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Cromwell-tools', 'Cromwell-tools Documentation',
-     author, 'Cromwell-tools', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        'Cromwell-tools',
+        'Cromwell-tools Documentation',
+        author,
+        'Cromwell-tools',
+        'One line description of project.',
+        'Miscellaneous',
+    )
 ]
 
 

--- a/notebooks/benchmark.py
+++ b/notebooks/benchmark.py
@@ -5,7 +5,14 @@ from google.oauth2 import service_account
 
 
 # ask about optional arguments
-def get_benchmark(output_dir, parent_workflow_name, cromwell_id, google_bucket, project_id, credentials=None):
+def get_benchmark(
+    output_dir,
+    parent_workflow_name,
+    cromwell_id,
+    google_bucket,
+    project_id,
+    credentials=None,
+):
     """
     Saves a monitoring log for the tasks being called by your pipeline as a combined file (JSON)
 
@@ -17,15 +24,21 @@ def get_benchmark(output_dir, parent_workflow_name, cromwell_id, google_bucket, 
     :param credentials: your credentials for google as a JSON file (optional
     """
 
-    calls = get_calls(google_bucket, project_id, parent_workflow_name, cromwell_id, credentials)
+    calls = get_calls(
+        google_bucket, project_id, parent_workflow_name, cromwell_id, credentials
+    )
 
     call_logs = get_call_logs(calls)
 
-    file_name = get_path(parent_workflow_name + "_" + cromwell_id + "_benchmark_logs.json", output_dir)
+    file_name = get_path(
+        parent_workflow_name + "_" + cromwell_id + "_benchmark_logs.json", output_dir
+    )
     store_benchmark(call_logs, file_name)
 
 
-def get_calls(google_bucket, project_id, parent_workflow_name, cromwell_id, credentials=None):
+def get_calls(
+    google_bucket, project_id, parent_workflow_name, cromwell_id, credentials=None
+):
     """
     :param google_bucket: the name of google bucket where your workflow was run
     :param project_id: The google project id for the workflow

--- a/notebooks/format_benchmark.py
+++ b/notebooks/format_benchmark.py
@@ -50,9 +50,7 @@ def convert_benchmark(output_dir, monitoring_log):
                 info = get_info("(\d*\.\d+|\d+)(M|G|T)$", line)
 
                 if info is not None:
-                    total_mem = {
-                        "size": float(info[0]),
-                        "unit": str(info[1]) + "B"}
+                    total_mem = {"size": float(info[0]), "unit": str(info[1]) + "B"}
 
             elif 'Total Disk space: ' in line:
                 info = get_info("(\d*\.\d+|\d+)(M|G|T)$", line)
@@ -60,10 +58,13 @@ def convert_benchmark(output_dir, monitoring_log):
                 if info is not None:
                     total_disk_sapce = {
                         "size": float(info[0]),
-                        "unit": str(info[1]) + "B"}
+                        "unit": str(info[1]) + "B",
+                    }
 
             elif '[' in line:
-                time_stamp = str(parser.parse(line.replace("[", '').replace("]", '').strip()))
+                time_stamp = str(
+                    parser.parse(line.replace("[", '').replace("]", '').strip())
+                )
 
             elif "CPU usage: " in line:
                 info = get_info("(\d*\.\d+|\d+)(%)$", line)
@@ -84,7 +85,12 @@ def convert_benchmark(output_dir, monitoring_log):
                 if info is not None:
                     disk_usage = float(info[0])
 
-                log = {"time": time_stamp, "cpu_usage": cpu_usage, "memory_usage": mem_usage, "disk_usage": disk_usage}
+                log = {
+                    "time": time_stamp,
+                    "cpu_usage": cpu_usage,
+                    "memory_usage": mem_usage,
+                    "disk_usage": disk_usage,
+                }
                 logs.append(log)
 
                 disk_usage = None
@@ -97,7 +103,8 @@ def convert_benchmark(output_dir, monitoring_log):
         summary = {
             "cores": num_of_cores,
             "memory": total_mem,
-            "disk_space": total_disk_sapce}
+            "disk_space": total_disk_sapce,
+        }
 
         call_log["summary"] = summary
         call_log["logs"] = logs

--- a/notebooks/plot_benchmark.py
+++ b/notebooks/plot_benchmark.py
@@ -1,12 +1,12 @@
-from dateutil import parser
 import json
 import re
 import os
 import pandas as pd
 import numpy as np
 import matplotlib
-matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
+
+matplotlib.use('TkAgg')
 
 
 def plot_benchmark(monitoring_log, parent_workflow_name, cromwell_id, output_dir):
@@ -60,10 +60,10 @@ def plot_memory_usage(calls_dict, parent_workflow_name, cromwell_id, output_dir)
             # if no other shards of the task have been stored in dict
             if task_name not in tasks:
                 # store total memory and max memory of current task call
-                total_memory =  str(call["summary"]["memory"]["size"]) + str(call["summary"]["memory"]["unit"])
-                tasks[task_name] = {
-                    "max_memory": 0.0,
-                    "total_memory": total_memory}
+                total_memory = str(call["summary"]["memory"]["size"]) + str(
+                    call["summary"]["memory"]["unit"]
+                )
+                tasks[task_name] = {"max_memory": 0.0, "total_memory": total_memory}
 
             # get max memory usage of current task call
             max_memory = 0.0
@@ -77,8 +77,9 @@ def plot_memory_usage(calls_dict, parent_workflow_name, cromwell_id, output_dir)
             if max_memory > tasks[task_name]["max_memory"]:
                 # save total memory and max memory of current task call
                 tasks[task_name]["max_memory"] = max_memory
-                tasks[task_name]["total_memory"] = str(call["summary"]["memory"]["size"]) \
-                    + str(call["summary"]["memory"]["unit"])
+                tasks[task_name]["total_memory"] = str(
+                    call["summary"]["memory"]["size"]
+                ) + str(call["summary"]["memory"]["unit"])
 
     task_calls = []
     total_memories = []
@@ -90,9 +91,13 @@ def plot_memory_usage(calls_dict, parent_workflow_name, cromwell_id, output_dir)
         total_memories.append(mem_info["total_memory"])
 
     # create data frame / format for plotting
-    data_frame = pd.DataFrame({"task calls": task_calls,
-                               "total memories": total_memories,
-                               "max memory usages": max_memory_usages})
+    data_frame = pd.DataFrame(
+        {
+            "task calls": task_calls,
+            "total memories": total_memories,
+            "max memory usages": max_memory_usages,
+        }
+    )
 
     if len(task_calls) > 0:
         data_frame = data_frame.sort_values("task calls")
@@ -122,7 +127,9 @@ def plot_memory_usage(calls_dict, parent_workflow_name, cromwell_id, output_dir)
     ax2.tick_params(axis="both", labelsize=4)
 
     # save plot
-    filename = get_path(parent_workflow_name + "_" + cromwell_id + "_memory_usage_plot.png", output_dir)
+    filename = get_path(
+        parent_workflow_name + "_" + cromwell_id + "_memory_usage_plot.png", output_dir
+    )
     plt.savefig(filename, dpi=1000, bbox_inches="tight")
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,8 @@
+black==19.3b0
+flake8==3.7.7
 mock>=2.0.0
-requests_mock>=1.4.0
+pre-commit==1.14.4
 pytest-cov>=2.5.1
 pytest>=3.6.3
 pytest-timeout>=1.3.1
+requests_mock>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.20.0
+requests>=2.20.0,<3
 six>=1.11.0
 google-auth>=1.6.1,<2
 setuptools_scm>=3.1.0,<4

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ CLASSIFIERS = [
 install_requires = [
     'requests>=2.20.0,<3',
     'six>=1.11.0',
-    'google-auth>=1.6.1,<2'
-    'setuptools_scm>=3.1.0,<4'
+    'google-auth>=1.6.1,<2' 'setuptools_scm>=3.1.0,<4',
 ]
 
 extras_require = {
@@ -29,25 +28,23 @@ extras_require = {
         'pre-commit==1.14.4',
         'pytest-cov>=2.5.1',
         'pytest>=3.6.3',
-        'pytest-timeout>=1.3.1'
+        'pytest-timeout>=1.3.1',
     ]
 }
 
-setup(name='cromwell-tools',
-      use_scm_version=True,
-      setup_requires=['setuptools_scm'],
-      description='Utilities for interacting with the Cromwell workflow engine',
-      classifiers=CLASSIFIERS,
-      url='http://github.com/broadinstitute/cromwell-tools',
-      author='Mint Team',
-      author_email='mintteam@broadinstitute.org',
-      license='BSD 3-clause "New" or "Revised" License',
-      packages=['cromwell_tools'],
-      install_requires=install_requires,
-      extras_require=extras_require,
-      entry_points={
-          'console_scripts': [
-              'cromwell-tools = cromwell_tools.cli:main'
-          ]
-      },
-      include_package_data=True)
+setup(
+    name='cromwell-tools',
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
+    description='Utilities for interacting with the Cromwell workflow engine',
+    classifiers=CLASSIFIERS,
+    url='http://github.com/broadinstitute/cromwell-tools',
+    author='Mint Team',
+    author_email='mintteam@broadinstitute.org',
+    license='BSD 3-clause "New" or "Revised" License',
+    packages=['cromwell_tools'],
+    install_requires=install_requires,
+    extras_require=extras_require,
+    entry_points={'console_scripts': ['cromwell-tools = cromwell_tools.cli:main']},
+    include_package_data=True,
+)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ CLASSIFIERS = [
 ]
 
 install_requires = [
-    'requests>=2.20.0',
+    'requests>=2.20.0,<3',
     'six>=1.11.0',
     'google-auth>=1.6.1,<2'
     'setuptools_scm>=3.1.0,<4'
@@ -22,8 +22,11 @@ install_requires = [
 
 extras_require = {
     'test': [
+        'black==19.3b0',
+        'flake8==3.7.7',
         'mock>=2.0.0',
         'requests_mock>=1.4.0',
+        'pre-commit==1.14.4',
         'pytest-cov>=2.5.1',
         'pytest>=3.6.3',
         'pytest-timeout>=1.3.1'


### PR DESCRIPTION
https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530

## Changes:
- [x] Add [Black](https://black.readthedocs.io/en/stable/index.html) as the code formatter for this repo.
- [x] Add Flake-8 and its configuration to the repo.
- [x] Update the Travis CI config so we have a linting test before all of the other tests.
- [x] Add `pre-commit` and update the requirements as well as the readme.
- [x] Add some status badges.
- [x] Drop support for Python 2.x
- [x] Drop support for womtool validation as well as the `validate` command. (Cromwell will provide this feature out-of-box via endpoint starting from v39)
 

## Review+QA Instructions:

- **Please expect the test to fail until we merge the PR 66 into this feature branch!!**
- Please check the new multi-stage test on Travis, especially verify that there is a new "linting test" before all tests.
- Please follow the updated readme, make sure the `pre-commit` is installed on your local environment and if feasible, try to make a commit (e.g. add an empty line to the readme, but don't push it), see if the hook works. **Using a virtualenv is highly recommended!**