### PR TITLE
Add support for JES-backend OAuth-enabled Cromwells

### DIFF
--- a/cromwell_tools/cromwell_api.py
+++ b/cromwell_tools/cromwell_api.py
@@ -202,6 +202,13 @@ class CromwellAPI(object):
             on_hold=on_hold,
         )
 
+        if auth.service_key_content:
+            submission_manifest[
+                'workflowOptions'
+            ] = utilities.compose_oauth_options_for_jes_backend_cromwell(
+                auth, submission_manifest['workflowOptions']
+            )
+
         if validate_labels and label_file is not None:
             validate_cromwell_label(submission_manifest['labels'])
 

--- a/cromwell_tools/tests/data/fake_account_key.json
+++ b/cromwell_tools/tests/data/fake_account_key.json
@@ -1,0 +1,4 @@
+{
+    "project_id": "fake-project",
+    "client_email": "fake-client-email"
+}

--- a/cromwell_tools/tests/test_cromwell_auth.py
+++ b/cromwell_tools/tests/test_cromwell_auth.py
@@ -1,10 +1,14 @@
 import os
 import tempfile
 import json
-import mock
+import six
 import pytest
 import requests
 from cromwell_tools.cromwell_auth import CromwellAuth
+
+
+six.add_move(six.MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock  # noqa
 
 
 def setup_auth_types():


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

- https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-236

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Cromwell as a Service using JES backend, as documented here: https://cromwell.readthedocs.io/en/develop/backends/Google/, requires the workflow submitter to include some special data in the workflow options file. This PR, in an inelegant way, adds those keys: `jes_gcs_root `, `google_project `, `google_compute_service_account ` and `user_service_account_json`. Some of them are only accessible when an user passes in the service account JSON key. So this PR:
- Adds a new property in the `CromAuth` class that stores the JSON key body.
- Adds a helper method that composes the required info into the existing options `io.ByteIO` stream.
- Adds the required unit test case.
- Fixes some Py2/3 compatibility code.


### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

(optional): If you want, you could test this feature by:
- Create a Python3.6 vritualenv
- clone this repo and checkout to my feature branch
- `pip install .` from within the root dir in the branch
- store the require JSON key file to a secure place locally: `vault read --format=json secret/dsde/mint/test/lira/caas-prod-key.json | jq ".data" >PATH/TO/THE/credentials.json`
- Run the following command to submit a workflow to CaaS prod:
```
cromwell-tools submit \
   --url "https://cromwell.caas-prod.broadinstitute.org" \
   --service-account-key "PATH/TO/THE/credentials.json" \
   -w "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/pipelines/optimus/Optimus.wdl" \
   -o "https://raw.githubusercontent.com/HumanCellAtlas/skylab-analysis/master/analyses/optimus/test_optimus_full_datasets/4k_pbmc/options.json" \
   -c "lira-test" \
   -l "https://raw.githubusercontent.com/HumanCellAtlas/skylab-analysis/master/analyses/optimus/test_optimus_full_datasets/4k_pbmc/labels.json" \
   -i "https://raw.githubusercontent.com/HumanCellAtlas/skylab-analysis/master/analyses/optimus/test_optimus_full_datasets/4k_pbmc/inputs_4k_pbmc.json" \
   -d "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/FastqToUBam.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/Attach10xBarcodes.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/SplitBamByCellBarcode.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/MergeSortBam.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/CreateCountMatrix.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/StarAlignBamSingleEnd.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/TagGeneExon.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/TagSortBam.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/RunEmptyDrops.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/ZarrUtils.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/Picard.wdl" \
   "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v1.0.0/library/tasks/MarkDuplicates.wdl"
```
- don't forget to abort the workflow:
```
cromwell-tools abort --url "https://cromwell.caas-prod.broadinstitute.org" --service-account-key "path/to/the/PATH/TO/THE/credentials.json" --uuid WORKFLOW_UUID
```