### PR TITLE
Fix git linguist analysis.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Exclude the documentation Jupyter Notebooks from the linguist so 
+# Exclude the documentation files from the linguist so 
 # the 'Jupyter Notebook' doesn't dominate the repo language
 
-docs/Tutorials/* linguist-generated=true
+docs/* linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Exclude the documentation Jupyter Notebooks from the linguist so 
+# the 'Jupyter Notebook' doesn't dominate the repo language
+
+docs/Tutorials/* linguist-generated=true


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

- This fixes the issue that Github Linguist is reporting cromwell-tools as a "Jupyter Notebook" rather than a `Python` repo. For more details, check https://github.com/github/linguist/blob/master/README.md#how-linguist-works and https://github.com/github/linguist/issues/3316

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- No changes.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
