### PR TITLE
updating travis badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Cromwell-tools
     :alt: Container Build Status
     
 .. image:: https://img.shields.io/travis/com/broadinstitute/cromwell-tools.svg?label=Unit%20Test%20on%20Travis%20CI%20&style=flat-square
-    :target: https://travis-ci.org/broadinstitute/cromwell-tools
+    :target: https://travis-ci.com/broadinstitute/cromwell-tools
     :alt: Unit Test Status
 
 .. image:: https://img.shields.io/readthedocs/cromwell-tools/latest.svg?label=ReadtheDocs%3A%20Latest&logo=Read%20the%20Docs&style=flat-square


### PR DESCRIPTION


### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->
The travis badge was pointing to the out of date travis-ci.org builds.  Updating it to point to .com.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->
Change badge link url to travis-ci.com

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Click badge, verify that it takes you to the right page.
