### PR TITLE
CLI shows help without args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 docker/cromwell-metadata/cromwell_credentials.txt
 docker/cromwell-metadata/caas_key.json
 
+# IDE
+.vscode/
+
 # Sphinx documentation
 docs/_build/
 

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Cromwell-tools
     :target: https://quay.io/repository/broadinstitute/cromwell-tools
     :alt: Container Build Status
     
-.. image:: https://github.com/broadinstitute/cromwell-tools/workflows/Tests%20on%20Pull%20Requests%20and%20Master/badge.svg?branch=master
-    :target: https://github.com/broadinstitute/cromwell-tools/actions?query=workflow%3A%22Tests+on+Pull+Requests+and+Master%22+branch%3Arex-switch-to-GithubActions
+.. image:: https://github.com/broadinstitute/cromwell-tools/workflows/Tests%20on%20Pull%20Requests%20and%20Master/badge.svg
+    :target: https://github.com/broadinstitute/cromwell-tools/actions?query=workflow%3A%22Tests+on+Pull+Requests+and+Master%22+branch%3Amaster
     :alt: Unit Test Status
 
 .. image:: https://img.shields.io/readthedocs/cromwell-tools/latest.svg?label=ReadtheDocs%3A%20Latest&logo=Read%20the%20Docs&style=flat-square

--- a/cromwell_tools/cli.py
+++ b/cromwell_tools/cli.py
@@ -4,15 +4,23 @@ from cromwell_tools.cromwell_api import CromwellAPI
 from cromwell_tools.cromwell_auth import CromwellAuth
 from cromwell_tools.diag import task_runtime
 from cromwell_tools import __version__
+import sys
 
 
 diagnostic_index = {'task_runtime': task_runtime.run}
 
 
+class DefaultHelpParser(argparse.ArgumentParser):
+    def error(self, message):
+        sys.stderr.write('error: %s\n' % message)
+        self.print_help()
+        sys.exit(2)
+
+
 def parser(arguments=None):
     # TODO: dynamically walk through the commands and automatcally create parsers here
 
-    main_parser = argparse.ArgumentParser()
+    main_parser = DefaultHelpParser()
 
     # Check the installed version of Cromwell-tools
     main_parser.add_argument(
@@ -245,6 +253,10 @@ def parser(arguments=None):
     )
     # query arguments
     # TODO: implement CLI entry for query API.
+
+    # Return help messages if no arguments provided
+    if not arguments:
+        main_parser.error("No arguments provided.")
 
     # group all of the arguments
     args = vars(main_parser.parse_args(arguments))

--- a/cromwell_tools/cli.py
+++ b/cromwell_tools/cli.py
@@ -254,12 +254,12 @@ def parser(arguments=None):
     # query arguments
     # TODO: implement CLI entry for query API.
 
-    # Return help messages if no arguments provided
-    if not arguments:
-        main_parser.error("No arguments provided.")
-
     # group all of the arguments
     args = vars(main_parser.parse_args(arguments))
+
+    # Return help messages if no arguments provided
+    if not args['command']:
+        main_parser.error("No commands/arguments provided!")
 
     # TODO: see if this can be moved or if the commands can be populated from above
     if args['command'] in (

--- a/cromwell_tools/cromwell_api.py
+++ b/cromwell_tools/cromwell_api.py
@@ -613,5 +613,5 @@ class CromwellAPI(object):
         if not response.ok:
             raise requests.exceptions.HTTPError(
                 'Error Code {0}: {1}'.format(response.status_code, response.text),
-                response=response
+                response=response,
             )


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

- https://github.com/broadinstitute/cromwell-tools/issues/97

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Some repo-level clean-ups.
- Fix the issue with CLI so it can show the help message when no commands/args provided.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

When run `cromwell-tools`, before:
```
TypeError: getattr(): attribute name must be string
```
now:
```bash
error: No commands/arguments provided!
usage: cromwell-tools [-h] [-V]
                      {submit,wait,status,abort,release_hold,metadata,query,health,task_runtime}
                      ...

positional arguments:
  {submit,wait,status,abort,release_hold,metadata,query,health,task_runtime}
                        sub-command help
    submit              submit help
    wait                wait help
    status              status help
    abort               abort help
    release_hold        release_hold help
    metadata            metadata help
    query               query help
    health              health help
    task_runtime        task_runtime help

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
```

